### PR TITLE
Add a new MCP server for table operations

### DIFF
--- a/mcp_pinot_ops/__init__.py
+++ b/mcp_pinot_ops/__init__.py
@@ -1,5 +1,7 @@
-from . import server
 import asyncio
+
+from . import server
+
 
 def main():
     """Main entry point for the package."""
@@ -7,4 +9,4 @@ def main():
 
 
 # Optionally expose other important items at package level
-__all__ = ['main', 'server']
+__all__ = ["main", "server"]

--- a/mcp_pinot_ops/prompts.py
+++ b/mcp_pinot_ops/prompts.py
@@ -1,16 +1,28 @@
-
 PROMPT_TEMPLATE_V1 = """
-Apache Pinot is a real-time distributed OLAP datastore purpose-built for low-latency, high-throughput analytics, and perfect for user-facing analytical workloads.
+Apache Pinot is a real-time distributed OLAP datastore purpose-built for
+low-latency, high-throughput analytics, and perfect for user-facing analytical
+workloads.
 
-Apache Pinot™ is a real-time distributed online analytical processing (OLAP) datastore. Use Pinot to ingest and immediately query data from streaming or batch data sources (including, Apache Kafka, Amazon Kinesis, Hadoop HDFS, Amazon S3, Azure ADLS, and Google Cloud Storage)
-. You can get a more detailed description and documentation about Apache Pinot using the docs at "https://docs.pinot.apache.org/" tool.
-The assistants goal is to get insights from a Pinot Workspace. To get those insights we will leverage this server to interact with pinot deployment. The user is a business decision maker with no previous knowledge of the data structure or insights inside the pinot Workspace.
+Apache Pinot is a real-time distributed online analytical processing (OLAP)
+datastore. Use Pinot to ingest and immediately query data from streaming or
+batch data sources (including Apache Kafka, Amazon Kinesis, Hadoop HDFS,
+Amazon S3, Azure ADLS, and Google Cloud Storage). You can get a more detailed
+description and documentation about Apache Pinot using the docs at
+"https://docs.pinot.apache.org/" tool. The assistant's goal is to get insights
+from a Pinot Workspace. To get those insights we will leverage this server to
+interact with Pinot deployment. The user is a business decision maker with no
+previous knowledge of the data structure or insights inside the Pinot
+Workspace.
 
-Your job is to simply execute READ Only Select queries from pinot using the python driver and help user visualise the data
+Your job is to simply execute READ-only SELECT queries from Pinot using the
+Python driver and help the user visualise the data.
 """
 
 PROMPT_TEMPLATE_V2 = """
-You are an AI analyst assistant for Apache Pinot, a real-time distributed OLAP datastore. Your role is to help users analyze Pinot data using natural language queries, convert these queries to SQL, suggest data visualizations, and ask clarifying questions when needed.
+You are an AI analyst assistant for Apache Pinot, a real-time distributed OLAP
+datastore. Your role is to help users analyze Pinot data using natural language
+queries, convert these queries to SQL, suggest data visualizations, and ask
+clarifying questions when needed.
 
 
 You have access to the following tools to assist in your analysis:
@@ -26,17 +38,28 @@ You have access to the following tools to assist in your analysis:
 
 When a user provides a query, follow these steps:
 
-1. Analyze the user's natural language query and identify the key elements (e.g., table, columns, filters, time range).
+1. Analyze the user's natural language query and identify the key elements
+   (e.g., table, columns, filters, time range).
 
-2. Based on the Pinot schema and the user's query, determine which table(s) and columns are relevant to the analysis.
+2. Based on the Pinot schema and the user's query, determine which table(s) and
+   columns are relevant to the analysis.
 
-3. Convert the natural language query into a SQL query that can be executed on Pinot. Ensure that the SQL query is optimized for Pinot's capabilities and follows best practices.
+3. Convert the natural language query into a SQL query that can be executed on
+   Pinot. Ensure that the SQL query is optimized for Pinot's capabilities and
+   follows best practices.
 
-4. If the query is ambiguous or lacks necessary information, formulate clarifying questions to ask the user. Present these questions clearly and concisely.
+4. If the query is ambiguous or lacks necessary information, formulate
+   clarifying questions to ask the user. Present these questions clearly and
+   concisely.
 
-5. Suggest appropriate data visualizations based on the nature of the query and the expected results. Consider charts, graphs, or other visual representations that would effectively communicate the insights.
+5. Suggest appropriate data visualizations based on the nature of the query and
+   the expected results. Consider charts, graphs, or other visual
+   representations that would effectively communicate the insights.
 
-6. If additional information about the schema, table configuration, or indexes is needed to optimize the query or provide better recommendations, use the appropriate tools (e.g., list-schema, table-details, index-column-details) to gather this information.
+6. If additional information about the schema, table configuration, or indexes
+   is needed to optimize the query or provide better recommendations, use the
+   appropriate tools (e.g., list-schema, table-details, index-column-details)
+   to gather this information.
 
 7. Present your findings in the following format:
 
@@ -62,10 +85,13 @@ When a user provides a query, follow these steps:
 </additional_insights>
 </analysis>
 
-Remember to always prioritize clarity and accuracy in your responses. If you're unsure about any aspect of the query or analysis, it's better to ask for clarification than to make assumptions.
+Remember to always prioritize clarity and accuracy in your responses. If you're
+unsure about any aspect of the query or analysis, it's better to ask for
+clarification than to make assumptions.
 """
 
 PROMPT_TEMPLATE = PROMPT_TEMPLATE_V2
+
 
 def generate_prompt(topic: str) -> str:
     return PROMPT_TEMPLATE.format(topic=topic)

--- a/mcp_pinot_ops/server.py
+++ b/mcp_pinot_ops/server.py
@@ -1,33 +1,25 @@
 # --------------------------
-# File: mcp_pinot/server.py
+# File: mcp_pinot_ops/server.py
 # --------------------------
 import asyncio
 import logging
+import sys
 from typing import Any
 
-import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 import mcp.server.stdio
-import sys
-from mcp_pinot.utils.pinot_client import (
-    PINOT_CONTROLLER_URL,
-    PINOT_USERNAME,
-    PINOT_PASSWORD,
-    PINOT_TOKEN,
-    PINOT_USE_MSQE,
-    HEADERS,
-    conn,
-    Pinot
-)
+import mcp.types as types
 
-from mcp_pinot.prompts import PROMPT_TEMPLATE
+from mcp_pinot_ops.prompts import PROMPT_TEMPLATE
+from mcp_pinot_ops.utils.pinot_client import Pinot
 
 logger = logging.getLogger("pinot_mcp_table_ops_claude")
 logger.setLevel(logging.INFO)
 
 # Use the imported Pinot class and connection values
 pinot_instance = Pinot()
+
 
 async def main():
     logger.info("Starting Pinot MCP Table Ops Server")
@@ -39,13 +31,18 @@ async def main():
         return [
             types.Prompt(
                 name="pinot-query",
-                description="A prompt to Query the pinot database with an Pinot MCP Server + Claude",
+                description=(
+                    "A prompt to query the Pinot database with a Pinot MCP "
+                    "Server + Claude"
+                ),
                 arguments=[],
             )
         ]
 
     @server.get_prompt()
-    async def handle_get_prompt(name: str, arguments: dict[str, str] | None) -> types.GetPromptResult:
+    async def handle_get_prompt(
+        name: str, arguments: dict[str, str] | None
+    ) -> types.GetPromptResult:
         if name != "pinot-query":
             raise ValueError(f"Unknown prompt: {name}")
         return types.GetPromptResult(
@@ -53,7 +50,9 @@ async def main():
             messages=[
                 types.PromptMessage(
                     role="user",
-                    content=types.TextContent(type="text", text=PROMPT_TEMPLATE.strip()),
+                    content=types.TextContent(
+                        type="text", text=PROMPT_TEMPLATE.strip()
+                    ),
                 )
             ],
         )
@@ -128,8 +127,14 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table"},
-                        "comment": {"type": "string", "description": "Optional comment"},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table",
+                        },
+                        "comment": {
+                            "type": "string",
+                            "description": "Optional comment",
+                        },
                     },
                     "required": ["tableName"],
                 },
@@ -140,9 +145,19 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table"},
-                        "comment": {"type": "string", "description": "Optional comment"},
-                        "consumeFrom": {"type": "string", "description": "lastConsumed | smallest | largest", "enum": ["lastConsumed", "smallest", "largest"]},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table",
+                        },
+                        "comment": {
+                            "type": "string",
+                            "description": "Optional comment",
+                        },
+                        "consumeFrom": {
+                            "type": "string",
+                            "description": "lastConsumed | smallest | largest",
+                            "enum": ["lastConsumed", "smallest", "largest"],
+                        },
                     },
                     "required": ["tableName"],
                 },
@@ -153,12 +168,34 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table"},
-                        "partitions": {"type": "string", "description": "Comma separated list of partition group IDs"},
-                        "segments": {"type": "string", "description": "Comma separated list of consuming segments"},
-                        "batchSize": {"type": "integer", "description": "Max segments to commit at once"},
-                        "batchStatusCheckIntervalSec": {"type": "integer", "description": "Interval to check batch status"},
-                        "batchStatusCheckTimeoutSec": {"type": "integer", "description": "Timeout for batch status check"},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table",
+                        },
+                        "partitions": {
+                            "type": "string",
+                            "description": (
+                                "Comma separated list of partition group IDs"
+                            ),
+                        },
+                        "segments": {
+                            "type": "string",
+                            "description": (
+                                "Comma separated list of consuming segments"
+                            ),
+                        },
+                        "batchSize": {
+                            "type": "integer",
+                            "description": "Max segments to commit at once",
+                        },
+                        "batchStatusCheckIntervalSec": {
+                            "type": "integer",
+                            "description": "Interval to check batch status",
+                        },
+                        "batchStatusCheckTimeoutSec": {
+                            "type": "integer",
+                            "description": "Timeout for batch status check",
+                        },
                     },
                     "required": ["tableName"],
                 },
@@ -169,34 +206,58 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table"},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table",
+                        },
                     },
                     "required": ["tableName"],
                 },
             ),
             types.Tool(
                 name="get_consuming_segments_info",
-                description="Gets the status of consumers from all servers for a realtime table",
+                description=(
+                    "Gets the status of consumers from all servers for a realtime table"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Realtime table name with or without type"},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Realtime table name with or without type",
+                        },
                     },
                     "required": ["tableName"],
                 },
             ),
             types.Tool(
                 name="reload-table-segments",
-                description="Reload all segments for a table (applies config changes, can force download)",
+                description=(
+                    "Reload all segments for a table (applies config changes, can "
+                    "force download)"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table"},
-                        "type": {"type": "string", "description": "OFFLINE or REALTIME", "enum": ["OFFLINE", "REALTIME"]},
-                        "forceDownload": {"type": "boolean", "description": "Whether to force servers to re-download segments", "default": False}
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table",
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "OFFLINE or REALTIME",
+                            "enum": ["OFFLINE", "REALTIME"],
+                        },
+                        "forceDownload": {
+                            "type": "boolean",
+                            "description": (
+                                "Whether to force servers to re-download segments"
+                            ),
+                            "default": False,
+                        },
                     },
                     "required": ["tableName"],
-                }
+                },
             ),
             types.Tool(
                 name="rebalance-table",
@@ -204,35 +265,82 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table to rebalance"},
-                        "type": {"type": "string", "description": "OFFLINE or REALTIME", "enum": ["OFFLINE", "REALTIME"]},
-                        "dryRun": {"type": "boolean", "description": "Dry run mode", "default": False},
-                        "reassignInstances": {"type": "boolean", "description": "Reassign instances before segments", "default": True},
-                        "includeConsuming": {"type": "boolean", "description": "Reassign CONSUMING segments (REALTIME only)", "default": True},
-                        "bootstrap": {"type": "boolean", "description": "Bootstrap mode (ignore minimal data movement)", "default": False},
-                        "downtime": {"type": "boolean", "description": "Allow downtime", "default": False},
-                        "minAvailableReplicas": {"type": "integer", "description": "Min replicas during no-downtime rebalance", "default": -1}
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table to rebalance",
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "OFFLINE or REALTIME",
+                            "enum": ["OFFLINE", "REALTIME"],
+                        },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "Dry run mode",
+                            "default": False,
+                        },
+                        "reassignInstances": {
+                            "type": "boolean",
+                            "description": "Reassign instances before segments",
+                            "default": True,
+                        },
+                        "includeConsuming": {
+                            "type": "boolean",
+                            "description": (
+                                "Reassign CONSUMING segments (REALTIME only)"
+                            ),
+                            "default": True,
+                        },
+                        "bootstrap": {
+                            "type": "boolean",
+                            "description": (
+                                "Bootstrap mode (ignore minimal data movement)"
+                            ),
+                            "default": False,
+                        },
+                        "downtime": {
+                            "type": "boolean",
+                            "description": "Allow downtime",
+                            "default": False,
+                        },
+                        "minAvailableReplicas": {
+                            "type": "integer",
+                            "description": "Min replicas during no-downtime rebalance",
+                            "default": -1,
+                        },
                         # Add other rebalance parameters as needed
                     },
                     "required": ["tableName", "type"],
-                }
+                },
             ),
             types.Tool(
                 name="reset-table-segments",
-                description="Resets segments for a table (disable->wait->enable). Use tableNameWithType (e.g., myTable_REALTIME)",
+                description=(
+                    "Resets segments for a table (disable->wait->enable). Use "
+                    "tableNameWithType (e.g., myTable_REALTIME)"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableNameWithType": {"type": "string", "description": "Table name with type suffix (e.g., myTable_REALTIME)"},
-                        "errorSegmentsOnly": {"type": "boolean", "description": "Reset only segments in ERROR state", "default": False}
+                        "tableNameWithType": {
+                            "type": "string",
+                            "description": (
+                                "Table name with type suffix (e.g., myTable_REALTIME)"
+                            ),
+                        },
+                        "errorSegmentsOnly": {
+                            "type": "boolean",
+                            "description": "Reset only segments in ERROR state",
+                            "default": False,
+                        },
                     },
                     "required": ["tableNameWithType"],
-                }
+                },
             ),
             types.Tool(
                 name="list-supported-indices",
                 description="List the types of indices supported by Pinot",
-                inputSchema={"type": "object", "properties": {}}
+                inputSchema={"type": "object", "properties": {}},
             ),
             types.Tool(
                 name="create-schema",
@@ -240,12 +348,23 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "schemaJson": {"type": "string", "description": "The schema definition in JSON format"},
-                        "override": {"type": "boolean", "description": "Override if schema exists", "default": True},
-                        "force": {"type": "boolean", "description": "Force override even if incompatible", "default": False}
+                        "schemaJson": {
+                            "type": "string",
+                            "description": "The schema definition in JSON format",
+                        },
+                        "override": {
+                            "type": "boolean",
+                            "description": "Override if schema exists",
+                            "default": True,
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "Force override even if incompatible",
+                            "default": False,
+                        },
                     },
                     "required": ["schemaJson"],
-                }
+                },
             ),
             types.Tool(
                 name="update-schema",
@@ -253,13 +372,29 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "schemaName": {"type": "string", "description": "Name of the schema to update"},
-                        "schemaJson": {"type": "string", "description": "The updated schema definition in JSON format"},
-                        "reload": {"type": "boolean", "description": "Reload table after update", "default": False},
-                        "force": {"type": "boolean", "description": "Force update even if incompatible", "default": False}
+                        "schemaName": {
+                            "type": "string",
+                            "description": "Name of the schema to update",
+                        },
+                        "schemaJson": {
+                            "type": "string",
+                            "description": (
+                                "The updated schema definition in JSON format"
+                            ),
+                        },
+                        "reload": {
+                            "type": "boolean",
+                            "description": "Reload table after update",
+                            "default": False,
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "Force update even if incompatible",
+                            "default": False,
+                        },
                     },
                     "required": ["schemaName", "schemaJson"],
-                }
+                },
             ),
             types.Tool(
                 name="create-table-config",
@@ -267,63 +402,175 @@ async def main():
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableConfigJson": {"type": "string", "description": "The table configuration in JSON format"},
-                         "validationTypesToSkip": {"type": "string", "description": "Comma-separated validation types to skip (ALL|TASK|UPSERT)"}
+                        "tableConfigJson": {
+                            "type": "string",
+                            "description": ("The table configuration in JSON format"),
+                        },
+                        "validationTypesToSkip": {
+                            "type": "string",
+                            "description": (
+                                "Comma-separated validation types to skip "
+                                "(ALL|TASK|UPSERT)"
+                            ),
+                        },
                     },
                     "required": ["tableConfigJson"],
-                }
+                },
             ),
             types.Tool(
                 name="update-table-config",
-                description="Updates an existing table configuration in Pinot (can be used to add/modify indices)",
+                description=(
+                    "Updates an existing table configuration in Pinot (can be used "
+                    "to add/modify indices)"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table to update"},
-                        "tableConfigJson": {"type": "string", "description": "The updated table configuration in JSON format"},
-                        "validationTypesToSkip": {"type": "string", "description": "Comma-separated validation types to skip (ALL|TASK|UPSERT)"}
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table to update",
+                        },
+                        "tableConfigJson": {
+                            "type": "string",
+                            "description": (
+                                "The updated table configuration in JSON format"
+                            ),
+                        },
+                        "validationTypesToSkip": {
+                            "type": "string",
+                            "description": (
+                                "Comma-separated validation types to skip "
+                                "(ALL|TASK|UPSERT)"
+                            ),
+                        },
                     },
                     "required": ["tableName", "tableConfigJson"],
-                }
+                },
             ),
             types.Tool(
                 name="add-index",
-                description="Adds a specified index type to one or more columns in a table config and optionally reloads",
+                description=(
+                    "Adds a specified index type to one or more columns in a table "
+                    "config and optionally reloads"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table (without type suffix)"},
-                        "tableType": {"type": "string", "description": "OFFLINE or REALTIME (required if table has both types)", "enum": ["OFFLINE", "REALTIME"]},
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table (without type suffix)",
+                        },
+                        "tableType": {
+                            "type": "string",
+                            "description": (
+                                "OFFLINE or REALTIME (required if table has both types)"
+                            ),
+                            "enum": ["OFFLINE", "REALTIME"],
+                        },
                         "indexType": {
                             "type": "string",
                             "description": "Type of index to add",
-                            "enum": ["inverted", "range", "text", "json", "bloom", "fst", "sorted"]
+                            "enum": [
+                                "inverted",
+                                "range",
+                                "text",
+                                "json",
+                                "bloom",
+                                "fst",
+                                "sorted",
+                            ],
                         },
-                        "columns": {"type": "array", "items": {"type": "string"}, "description": "List of column names to add the index to"},
-                        "triggerReload": {"type": "boolean", "description": "Reload the table segments after updating config", "default": True}
-                        # Specific index configs (e.g., for JSON, FST) could be added here if needed
+                        "columns": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": ("List of column names to add the index to"),
+                        },
+                        "triggerReload": {
+                            "type": "boolean",
+                            "description": (
+                                "Reload the table segments after updating config"
+                            ),
+                            "default": True,
+                        },
+                        # Specific index configs (e.g., for JSON, FST) could be added
+                        # here if needed
                     },
                     "required": ["tableName", "indexType", "columns"],
-                }
+                },
             ),
             types.Tool(
                 name="add-startree-index",
-                description="Adds a Star-Tree index configuration to a table config and optionally reloads.",
+                description=(
+                    "Adds a Star-Tree index configuration to a table config and "
+                    "optionally reloads."
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "tableName": {"type": "string", "description": "Name of the table (without type suffix)"},
-                        "tableType": {"type": "string", "description": "OFFLINE or REALTIME (required if table has both types)", "enum": ["OFFLINE", "REALTIME"]},
-                        "dimensionsSplitOrder": {"type": "array", "items": {"type": "string"}, "description": "List of dimension columns defining the tree structure"},
-                        "functionColumnPairs": {"type": "array", "items": {"type": "string"}, "description": "Optional. Aggregations like [\"SUM__colA\", \"COUNT__*\"]. Use this OR aggregationConfigsJson.", "default": []},
-                        "aggregationConfigsJson": {"type": "string", "description": "Optional. JSON string for the 'aggregationConfigs' array (alternative to functionColumnPairs)."},
-                        "skipStarNodeCreationForDimensions": {"type": "array", "items": {"type": "string"}, "description": "Optional. Dimensions for which to skip the Star-node creation.", "default": []},
-                        "maxLeafRecords": {"type": "integer", "description": "Optional. Threshold T to determine whether to split nodes further.", "default": 10000},
-                        "triggerReload": {"type": "boolean", "description": "Reload the table segments after updating config (Note: Star-Tree often needs segment regeneration)", "default": True}
+                        "tableName": {
+                            "type": "string",
+                            "description": "Name of the table (without type suffix)",
+                        },
+                        "tableType": {
+                            "type": "string",
+                            "description": (
+                                "OFFLINE or REALTIME (required if table has both types)"
+                            ),
+                            "enum": ["OFFLINE", "REALTIME"],
+                        },
+                        "dimensionsSplitOrder": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "List of dimension columns defining the tree structure"
+                            ),
+                        },
+                        "functionColumnPairs": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                'Optional. Aggregations like ["SUM__colA", '
+                                '"COUNT__*"]. Use this OR aggregationConfigsJson.'
+                            ),
+                            "default": [],
+                        },
+                        "aggregationConfigsJson": {
+                            "type": "string",
+                            "description": (
+                                "Optional. JSON string for the "
+                                "'aggregationConfigs' array (alternative to "
+                                "functionColumnPairs)."
+                            ),
+                        },
+                        "skipStarNodeCreationForDimensions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional. Dimensions for which to skip the "
+                                "Star-node creation."
+                            ),
+                            "default": [],
+                        },
+                        "maxLeafRecords": {
+                            "type": "integer",
+                            "description": (
+                                "Optional. Threshold T to determine whether to split "
+                                "nodes further."
+                            ),
+                            "default": 10000,
+                        },
+                        "triggerReload": {
+                            "type": "boolean",
+                            "description": (
+                                "Reload the table segments after updating config "
+                                "(Note: Star-Tree often needs segment regeneration)"
+                            ),
+                            "default": True,
+                        },
                     },
                     "required": ["tableName", "dimensionsSplitOrder"],
-                }
-            )
+                },
+            ),
         ]
 
     @server.call_tool()
@@ -333,7 +580,9 @@ async def main():
         """Handle tool execution requests"""
         try:
             if name == "table-details":
-                results = pinot_instance._get_table_detail(tableName=arguments["tableName"])
+                results = pinot_instance._get_table_detail(
+                    tableName=arguments["tableName"]
+                )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "segment-list":
@@ -343,16 +592,20 @@ async def main():
             elif name == "index-column-details":
                 results = pinot_instance._get_index_column_detail(
                     tableName=arguments["tableName"],
-                    segmentName=arguments["segmentName"]
+                    segmentName=arguments["segmentName"],
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "segment-metadata-details":
-                results = pinot_instance._get_segment__metadata_detail(tableName=arguments["tableName"])
+                results = pinot_instance._get_segment_metadata_detail(
+                    tableName=arguments["tableName"]
+                )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "tableconfig-schema-details":
-                results = pinot_instance._get_tableconfig_schema_detail(tableName=arguments["tableName"])
+                results = pinot_instance._get_tableconfig_schema_detail(
+                    tableName=arguments["tableName"]
+                )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "list-tables":
@@ -361,8 +614,7 @@ async def main():
 
             elif name == "pause_consumption":
                 results = pinot_instance._pause_consumption(
-                    tableName=arguments["tableName"],
-                    comment=arguments.get("comment")
+                    tableName=arguments["tableName"], comment=arguments.get("comment")
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -370,7 +622,7 @@ async def main():
                 results = pinot_instance._resume_consumption(
                     tableName=arguments["tableName"],
                     comment=arguments.get("comment"),
-                    consumeFrom=arguments.get("consumeFrom")
+                    consumeFrom=arguments.get("consumeFrom"),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -380,24 +632,32 @@ async def main():
                     partitions=arguments.get("partitions"),
                     segments=arguments.get("segments"),
                     batchSize=arguments.get("batchSize"),
-                    batchStatusCheckIntervalSec=arguments.get("batchStatusCheckIntervalSec"),
-                    batchStatusCheckTimeoutSec=arguments.get("batchStatusCheckTimeoutSec")
+                    batchStatusCheckIntervalSec=arguments.get(
+                        "batchStatusCheckIntervalSec"
+                    ),
+                    batchStatusCheckTimeoutSec=arguments.get(
+                        "batchStatusCheckTimeoutSec"
+                    ),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "get_pause_status":
-                results = pinot_instance._get_pause_status(tableName=arguments["tableName"])
+                results = pinot_instance._get_pause_status(
+                    tableName=arguments["tableName"]
+                )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "get_consuming_segments_info":
-                results = pinot_instance._get_consuming_segments_info(tableName=arguments["tableName"])
+                results = pinot_instance._get_consuming_segments_info(
+                    tableName=arguments["tableName"]
+                )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "reload-table-segments":
                 results = pinot_instance._reload_table_segments(
                     tableName=arguments["tableName"],
-                    tableType=arguments.get("type"), # API uses 'type' query param
-                    forceDownload=arguments.get("forceDownload", False)
+                    tableType=arguments.get("type"),  # API uses 'type' query param
+                    forceDownload=arguments.get("forceDownload", False),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -410,40 +670,51 @@ async def main():
                     includeConsuming=arguments.get("includeConsuming", True),
                     bootstrap=arguments.get("bootstrap", False),
                     downtime=arguments.get("downtime", False),
-                    minAvailableReplicas=arguments.get("minAvailableReplicas", -1)
+                    minAvailableReplicas=arguments.get("minAvailableReplicas", -1),
                     # Pass other params as needed
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "reset-table-segments":
-                 results = pinot_instance._reset_table_segments(
+                results = pinot_instance._reset_table_segments(
                     tableNameWithType=arguments["tableNameWithType"],
-                    errorSegmentsOnly=arguments.get("errorSegmentsOnly", False)
+                    errorSegmentsOnly=arguments.get("errorSegmentsOnly", False),
                 )
-                 return [types.TextContent(type="text", text=str(results))]
+                return [types.TextContent(type="text", text=str(results))]
 
             elif name == "list-supported-indices":
                 # Based on web search and swagger definitions
                 supported_indices = [
-                    "Forward Index (Dictionary-encoded, Sorted, Raw Value) - Default, based on encoding/sorting",
+                    (
+                        "Forward Index (Dictionary-encoded, Sorted, Raw Value) - "
+                        "Default, based on encoding/sorting"
+                    ),
                     "Inverted Index (Bitmap, Sorted) - For exact match filtering",
                     "Range Index - For range filtering (<, >, <=, >=)",
                     "Text Index (Native/Lucene) - For text search queries",
                     "JSON Index - For filtering fields within JSON blobs",
-                    "Geospatial Index (H3) - For geospatial distance/containment queries",
+                    (
+                        "Geospatial Index (H3) - For geospatial "
+                        "distance/containment queries"
+                    ),
                     "Timestamp Index - Optimized time filtering",
                     "Vector Index - For vector similarity search",
                     "Bloom Filter - Probabilistic filter to skip segments",
                     "Star-Tree Index - Pre-aggregation cube.",
-                    "FST Index - For prefix/regex matching on dictionary-encoded columns"
+                    (
+                        "FST Index - For prefix/regex matching on "
+                        "dictionary-encoded columns"
+                    ),
                 ]
-                return [types.TextContent(type="text", text="\n".join(supported_indices))]
+                return [
+                    types.TextContent(type="text", text="\n".join(supported_indices))
+                ]
 
             elif name == "create-schema":
                 results = pinot_instance._create_schema(
                     schemaJson=arguments["schemaJson"],
                     override=arguments.get("override", True),
-                    force=arguments.get("force", False)
+                    force=arguments.get("force", False),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -452,14 +723,14 @@ async def main():
                     schemaName=arguments["schemaName"],
                     schemaJson=arguments["schemaJson"],
                     reload=arguments.get("reload", False),
-                    force=arguments.get("force", False)
+                    force=arguments.get("force", False),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "create-table-config":
                 results = pinot_instance._create_table_config(
                     tableConfigJson=arguments["tableConfigJson"],
-                    validationTypesToSkip=arguments.get("validationTypesToSkip")
+                    validationTypesToSkip=arguments.get("validationTypesToSkip"),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -467,7 +738,7 @@ async def main():
                 results = pinot_instance._update_table_config(
                     tableName=arguments["tableName"],
                     tableConfigJson=arguments["tableConfigJson"],
-                    validationTypesToSkip=arguments.get("validationTypesToSkip")
+                    validationTypesToSkip=arguments.get("validationTypesToSkip"),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -477,14 +748,19 @@ async def main():
                     tableType=arguments.get("tableType"),
                     indexType=arguments["indexType"],
                     columns=arguments["columns"],
-                    triggerReload=arguments.get("triggerReload", True)
+                    triggerReload=arguments.get("triggerReload", True),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "add-startree-index":
-                # Basic validation: Ensure either functionColumnPairs or aggregationConfigsJson is provided (or neither is fine)
-                if arguments.get("functionColumnPairs") and arguments.get("aggregationConfigsJson"):
-                     raise ValueError("Provide either 'functionColumnPairs' or 'aggregationConfigsJson', not both.")
+                # Ensure only one of functionColumnPairs/aggregationConfigsJson is set
+                if arguments.get("functionColumnPairs") and arguments.get(
+                    "aggregationConfigsJson"
+                ):
+                    raise ValueError(
+                        "Provide either 'functionColumnPairs' or "
+                        "'aggregationConfigsJson', not both."
+                    )
 
                 results = pinot_instance._add_star_tree_index(
                     tableName=arguments["tableName"],
@@ -492,9 +768,11 @@ async def main():
                     dimensionsSplitOrder=arguments["dimensionsSplitOrder"],
                     functionColumnPairs=arguments.get("functionColumnPairs", []),
                     aggregationConfigsJson=arguments.get("aggregationConfigsJson"),
-                    skipStarNodeCreationForDimensions=arguments.get("skipStarNodeCreationForDimensions", []),
+                    skipStarNodeCreationForDimensions=arguments.get(
+                        "skipStarNodeCreationForDimensions", []
+                    ),
                     maxLeafRecords=arguments.get("maxLeafRecords", 10000),
-                    triggerReload=arguments.get("triggerReload", True)
+                    triggerReload=arguments.get("triggerReload", True),
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
@@ -521,12 +799,15 @@ async def main():
             )
     except Exception as e:
         import traceback
+
         logger.error(f"Error running MCP server: {e}")
         logger.error(traceback.format_exc())
         print(f"Error running MCP server: {e}", file=sys.stderr)
         print(traceback.format_exc(), file=sys.stderr)
         raise
 
+
 if __name__ == "__main__":
     import asyncio
+
     asyncio.run(main())

--- a/mcp_pinot_ops/utils/__init__.py
+++ b/mcp_pinot_ops/utils/__init__.py
@@ -1,3 +1,3 @@
 """
 Utils package for MCP Pinot server.
-""" 
+"""

--- a/mcp_pinot_ops/utils/pinot_client.py
+++ b/mcp_pinot_ops/utils/pinot_client.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Any
-import pandas as pd
-import requests
-import mcp.types as types
-from pinotdb import connect
 import os
+from typing import Any
+
 from dotenv import load_dotenv
+import pandas as pd
+from pinotdb import connect
+import requests
 
 # Load environment variables from .env file
 load_dotenv()
@@ -28,6 +28,8 @@ HEADERS = {
 if PINOT_TOKEN:
     HEADERS["Authorization"] = PINOT_TOKEN
 
+REQUEST_TIMEOUT = 30
+
 conn = connect(
     host=PINOT_BROKER_HOST,
     port=PINOT_BROKER_PORT,
@@ -43,7 +45,9 @@ class Pinot:
     def __init__(self):
         self.insights: list[str] = []
 
-    def _execute_query(self, query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    def _execute_query(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
         logger.debug(f"Executing query: {query}")
         curs = conn.cursor()
         curs.execute(query)
@@ -52,56 +56,79 @@ class Pinot:
 
     def _get_tables(self, params: dict[str, Any] | None = None) -> list[str]:
         url = f"{PINOT_CONTROLLER_URL}/tables"
-        return requests.get(url, headers=HEADERS).json()["tables"]
+        return requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT).json()[
+            "tables"
+        ]
 
-    def _get_table_detail(self, tableName: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _get_table_detail(
+        self, tableName: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/size"
-        return requests.get(url, headers=HEADERS).json()
+        return requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT).json()
 
-    def _get_segment__metadata_detail(self, tableName: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _get_segment_metadata_detail(
+        self, tableName: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/segments/{tableName}/metadata"
-        return requests.get(url, headers=HEADERS).json()
+        return requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT).json()
 
-    def _get_segments(self, tableName: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _get_segments(
+        self, tableName: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/segments/{tableName}"
-        return requests.get(url, headers=HEADERS).json()
+        return requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT).json()
 
-    def _get_index_column_detail(self, tableName: str, segmentName: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _get_index_column_detail(
+        self, tableName: str, segmentName: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         for type_suffix in ["REALTIME", "OFFLINE"]:
-            url = f"{PINOT_CONTROLLER_URL}/segments/{tableName}_{type_suffix}/{segmentName}/metadata?columns=*"
-            response = requests.get(url, headers=HEADERS)
+            url = (
+                f"{PINOT_CONTROLLER_URL}/segments/{tableName}_{type_suffix}/"
+                f"{segmentName}/metadata?columns=*"
+            )
+            response = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
             if response.status_code == 200:
                 return response.json()
         raise ValueError("Index column detail not found")
 
-    def _get_tableconfig_schema_detail(self, tableName: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _get_tableconfig_schema_detail(
+        self, tableName: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tableConfigs/{tableName}"
-        return requests.get(url, headers=HEADERS).json()
+        return requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT).json()
 
-    def _pause_consumption(self, tableName: str, comment: str | None = None) -> dict[str, Any]:
+    def _pause_consumption(
+        self, tableName: str, comment: str | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/pauseConsumption"
         params = {}
         if comment:
             params["comment"] = comment
-        response = requests.post(url, headers=HEADERS, params=params)
-        response.raise_for_status() # Raise an exception for bad status codes
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
+        response.raise_for_status()  # Raise an exception for bad status codes
         # Check if response body is empty or just whitespace
         if not response.text or response.text.isspace():
             return {"status": "success", "message": "Pause request sent successfully."}
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            # Handle cases where response is not JSON but status code is OK (e.g., 200 OK with plain text)
+            # Handle OK responses that return non-JSON (e.g., 200 with plain text)
             return {"status": "success", "response_body": response.text}
 
-    def _resume_consumption(self, tableName: str, comment: str | None = None, consumeFrom: str | None = None) -> dict[str, Any]:
+    def _resume_consumption(
+        self, tableName: str, comment: str | None = None, consumeFrom: str | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/resumeConsumption"
         params = {}
         if comment:
             params["comment"] = comment
         if consumeFrom:
             params["consumeFrom"] = consumeFrom
-        response = requests.post(url, headers=HEADERS, params=params)
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         if not response.text or response.text.isspace():
             return {"status": "success", "message": "Resume request sent successfully."}
@@ -110,9 +137,15 @@ class Pinot:
         except requests.exceptions.JSONDecodeError:
             return {"status": "success", "response_body": response.text}
 
-    def _force_commit(self, tableName: str, partitions: str | None = None, segments: str | None = None,
-                      batchSize: int | None = None, batchStatusCheckIntervalSec: int | None = None,
-                      batchStatusCheckTimeoutSec: int | None = None) -> dict[str, Any]:
+    def _force_commit(
+        self,
+        tableName: str,
+        partitions: str | None = None,
+        segments: str | None = None,
+        batchSize: int | None = None,
+        batchStatusCheckIntervalSec: int | None = None,
+        batchStatusCheckTimeoutSec: int | None = None,
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/forceCommit"
         params = {}
         if partitions:
@@ -126,56 +159,79 @@ class Pinot:
         if batchStatusCheckTimeoutSec is not None:
             params["batchStatusCheckTimeoutSec"] = batchStatusCheckTimeoutSec
 
-        response = requests.post(url, headers=HEADERS, params=params)
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         if not response.text or response.text.isspace():
-            # The API spec indicates a response schema, but let's handle empty responses gracefully
+            # Handle empty responses even though a schema is expected
             return {"status": "success", "message": "Force commit request submitted."}
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-             return {"status": "success", "response_body": response.text}
+            return {"status": "success", "response_body": response.text}
 
     def _get_pause_status(self, tableName: str) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/pauseStatus"
-        response = requests.get(url, headers=HEADERS)
+        response = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
         if not response.text or response.text.isspace():
-            return {"status": "success", "message": "Pause status retrieved, but response was empty."}
+            return {
+                "status": "success",
+                "message": "Pause status retrieved, but response was empty.",
+            }
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-             return {"status": "success", "response_body": response.text}
+            return {"status": "success", "response_body": response.text}
 
     def _get_consuming_segments_info(self, tableName: str) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/consumingSegmentsInfo"
-        response = requests.get(url, headers=HEADERS)
+        response = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            # The API spec indicates a response schema, so this shouldn't usually happen on success
-            return {"status": "error", "message": "Failed to decode JSON response", "response_body": response.text}
+            # Unexpected non-JSON response for a successful request
+            return {
+                "status": "error",
+                "message": "Failed to decode JSON response",
+                "response_body": response.text,
+            }
 
-    def _reload_table_segments(self, tableName: str, tableType: str | None = None, forceDownload: bool = False) -> dict[str, Any]:
+    def _reload_table_segments(
+        self, tableName: str, tableType: str | None = None, forceDownload: bool = False
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/segments/{tableName}/reload"
-        params = {
-            "forceDownload": str(forceDownload).lower()
-        }
+        params = {"forceDownload": str(forceDownload).lower()}
         if tableType:
             params["type"] = tableType
 
-        response = requests.post(url, headers=HEADERS, params=params)
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            return {"status": "success", "message": "Reload request sent.", "response_body": response.text}
+            return {
+                "status": "success",
+                "message": "Reload request sent.",
+                "response_body": response.text,
+            }
 
-    def _rebalance_table(self, tableName: str, tableType: str,
-                         dryRun: bool = False, reassignInstances: bool = True, includeConsuming: bool = True,
-                         bootstrap: bool = False, downtime: bool = False, minAvailableReplicas: int = -1,
-                         **kwargs) -> dict[str, Any]:
+    def _rebalance_table(
+        self,
+        tableName: str,
+        tableType: str,
+        dryRun: bool = False,
+        reassignInstances: bool = True,
+        includeConsuming: bool = True,
+        bootstrap: bool = False,
+        downtime: bool = False,
+        minAvailableReplicas: int = -1,
+        **kwargs,
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}/rebalance"
         params = {
             "type": tableType,
@@ -184,48 +240,64 @@ class Pinot:
             "includeConsuming": str(includeConsuming).lower(),
             "bootstrap": str(bootstrap).lower(),
             "downtime": str(downtime).lower(),
-            "minAvailableReplicas": minAvailableReplicas
+            "minAvailableReplicas": minAvailableReplicas,
         }
         # Add any other optional params passed via kwargs
         for k, v in kwargs.items():
             if v is not None:
-                 # Convert boolean values to lowercase strings for Pinot API
+                # Convert boolean values to lowercase strings for Pinot API
                 if isinstance(v, bool):
                     params[k] = str(v).lower()
                 else:
                     params[k] = v
 
-        response = requests.post(url, headers=HEADERS, params=params)
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            return {"status": "success", "message": "Rebalance request sent.", "response_body": response.text}
+            return {
+                "status": "success",
+                "message": "Rebalance request sent.",
+                "response_body": response.text,
+            }
 
-    def _reset_table_segments(self, tableNameWithType: str, errorSegmentsOnly: bool = False) -> dict[str, Any]:
+    def _reset_table_segments(
+        self, tableNameWithType: str, errorSegmentsOnly: bool = False
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/segments/{tableNameWithType}/reset"
-        params = {
-            "errorSegmentsOnly": str(errorSegmentsOnly).lower()
-        }
-        response = requests.post(url, headers=HEADERS, params=params)
+        params = {"errorSegmentsOnly": str(errorSegmentsOnly).lower()}
+        response = requests.post(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            return {"status": "success", "message": "Reset segments request sent.", "response_body": response.text}
+            return {
+                "status": "success",
+                "message": "Reset segments request sent.",
+                "response_body": response.text,
+            }
 
-    def _create_schema(self, schemaJson: str, override: bool = True, force: bool = False) -> dict[str, Any]:
+    def _create_schema(
+        self, schemaJson: str, override: bool = True, force: bool = False
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/schemas"
-        params = {
-            "override": str(override).lower(),
-            "force": str(force).lower()
-        }
-        # The API expects multipart/form-data or application/json based on swagger, but examples use form data.
-        # Let's try sending JSON directly first, as it's simpler. Check swagger again - it lists FormDataMultiPart.
-        # Trying with JSON body. If this fails, might need multipart handling.
+        params = {"override": str(override).lower(), "force": str(force).lower()}
+        # API accepts multipart or JSON. Try JSON first; fallback multipart code is
+        # left commented below if needed.
         headers = HEADERS.copy()
-        headers['Content-Type'] = 'application/json'
-        response = requests.post(url, headers=headers, params=params, data=schemaJson)
+        headers["Content-Type"] = "application/json"
+        response = requests.post(
+            url,
+            headers=headers,
+            params=params,
+            data=schemaJson,
+            timeout=REQUEST_TIMEOUT,
+        )
 
         # If JSON fails, try multipart (more complex to construct)
         # if response.status_code >= 400:
@@ -236,75 +308,124 @@ class Pinot:
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-             # Handle cases like 200 OK with non-JSON success message
-             return {"status": "success", "message": "Schema creation request processed.", "response_body": response.text}
+            # Handle cases like 200 OK with non-JSON success message
+            return {
+                "status": "success",
+                "message": "Schema creation request processed.",
+                "response_body": response.text,
+            }
 
-    def _update_schema(self, schemaName: str, schemaJson: str, reload: bool = False, force: bool = False) -> dict[str, Any]:
+    def _update_schema(
+        self,
+        schemaName: str,
+        schemaJson: str,
+        reload: bool = False,
+        force: bool = False,
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/schemas/{schemaName}"
-        params = {
-            "reload": str(reload).lower(),
-            "force": str(force).lower()
-        }
+        params = {"reload": str(reload).lower(), "force": str(force).lower()}
         headers = HEADERS.copy()
-        headers['Content-Type'] = 'application/json'
-        response = requests.put(url, headers=headers, params=params, data=schemaJson)
+        headers["Content-Type"] = "application/json"
+        response = requests.put(
+            url,
+            headers=headers,
+            params=params,
+            data=schemaJson,
+            timeout=REQUEST_TIMEOUT,
+        )
         response.raise_for_status()
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError:
-            return {"status": "success", "message": "Schema update request processed.", "response_body": response.text}
+            return {
+                "status": "success",
+                "message": "Schema update request processed.",
+                "response_body": response.text,
+            }
 
-    def _create_table_config(self, tableConfigJson: str, validationTypesToSkip: str | None = None) -> dict[str, Any]:
+    def _create_table_config(
+        self, tableConfigJson: str, validationTypesToSkip: str | None = None
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables"
         params = {}
         if validationTypesToSkip:
             params["validationTypesToSkip"] = validationTypesToSkip
         headers = HEADERS.copy()
-        headers['Content-Type'] = 'application/json'
-        response = requests.post(url, headers=headers, params=params, data=tableConfigJson)
+        headers["Content-Type"] = "application/json"
+        response = requests.post(
+            url,
+            headers=headers,
+            params=params,
+            data=tableConfigJson,
+            timeout=REQUEST_TIMEOUT,
+        )
         response.raise_for_status()
-        return response.json() # Expects JSON response based on swagger
+        return response.json()  # Expects JSON response based on swagger
 
-    def _update_table_config(self, tableName: str, tableConfigJson: str, validationTypesToSkip: str | None = None) -> dict[str, Any]:
+    def _update_table_config(
+        self,
+        tableName: str,
+        tableConfigJson: str,
+        validationTypesToSkip: str | None = None,
+    ) -> dict[str, Any]:
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}"
         params = {}
         if validationTypesToSkip:
             params["validationTypesToSkip"] = validationTypesToSkip
         headers = HEADERS.copy()
-        headers['Content-Type'] = 'application/json'
-        response = requests.put(url, headers=headers, params=params, data=tableConfigJson)
+        headers["Content-Type"] = "application/json"
+        response = requests.put(
+            url,
+            headers=headers,
+            params=params,
+            data=tableConfigJson,
+            timeout=REQUEST_TIMEOUT,
+        )
         response.raise_for_status()
-        return response.json() # Expects JSON response based on swagger
+        return response.json()  # Expects JSON response based on swagger
 
-    def _get_table_config(self, tableName: str, tableType: str | None = None) -> dict[str, Any]:
-        """Gets the table config for a specific table. Use tableType for REALTIME/OFFLINE specificity if needed, but /tables/{tableName} GET might return combined.
-           Checking swagger: GET /tables/{tableName} returns config based on 'type' query param or combined.
-           Let's assume we get the config we need to PUT back.
+    def _get_table_config(
+        self, tableName: str, tableType: str | None = None
+    ) -> dict[str, Any]:
+        """Get the table config for a table.
+
+        Use tableType for REALTIME/OFFLINE specificity if needed. The GET API
+        can return combined configs; the caller should select the right section
+        when issuing a subsequent PUT.
         """
         url = f"{PINOT_CONTROLLER_URL}/tables/{tableName}"
         params = {}
         if tableType:
-            params["type"] = tableType # Query param for GET
+            params["type"] = tableType  # Query param for GET
 
-        response = requests.get(url, headers=HEADERS, params=params)
+        response = requests.get(
+            url, headers=HEADERS, params=params, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
-        # The response for GET /tables/{tableName} returns a structure like {"OFFLINE": {config...}, "REALTIME": {config...}}
-        # or just {config...} if type is specified. The PUT /tables/{tableName} expects just the config object.
-        # We need to handle this. Let's return the raw response for now, the caller needs to extract the right part.
-        # Or, we can try to be smarter if tableType is provided.
+        # GET /tables/{tableName} may return {"OFFLINE": {...}, "REALTIME": {...}}
+        # or a single config object if a type is specified. Return the raw JSON
+        # and let the caller extract the appropriate section.
         raw_response = response.json()
         if tableType and tableType.upper() in raw_response:
-            return raw_response[tableType.upper()] # Return specific type config
-        elif not tableType and ("OFFLINE" in raw_response or "REALTIME" in raw_response):
+            return raw_response[tableType.upper()]  # Return specific type config
+        elif not tableType and (
+            "OFFLINE" in raw_response or "REALTIME" in raw_response
+        ):
             # If type not specified, return the whole structure if it contains types
             # Or maybe just return the first one found? Let's return the whole thing.
-             return raw_response
+            return raw_response
         else:
-             # Assume it's the direct config if no types are keys
-             return raw_response
+            # Assume it's the direct config if no types are keys
+            return raw_response
 
-    def _add_index(self, tableName: str, indexType: str, columns: list[str],
-                     tableType: str | None = None, triggerReload: bool = True) -> dict[str, Any]:
+    def _add_index(
+        self,
+        tableName: str,
+        indexType: str,
+        columns: list[str],
+        tableType: str | None = None,
+        triggerReload: bool = True,
+    ) -> dict[str, Any]:
         """Adds an index configuration to a table and optionally reloads.
 
         Args:
@@ -320,39 +441,43 @@ class Pinot:
         import json
 
         try:
-            # 1. Get current table config
-            # We need the specific config (OFFLINE or REALTIME) or the combined one if only one type exists
-            # The _get_table_config handles fetching the specific type if provided, or the combined dict otherwise.
+            # 1. Get current table config (specific type if provided)
             current_config_response = self._get_table_config(tableName, tableType)
 
             # Determine which config object to modify
             if tableType:
-                config_to_modify = current_config_response # _get_table_config returns the specific type
+                config_to_modify = current_config_response
             elif "OFFLINE" in current_config_response:
                 config_to_modify = current_config_response["OFFLINE"]
-                if tableType is None: tableType = "OFFLINE" # Default to modifying OFFLINE if type unspecified
+                if tableType is None:
+                    tableType = (
+                        "OFFLINE"  # Default to modifying OFFLINE if type unspecified
+                    )
             elif "REALTIME" in current_config_response:
                 config_to_modify = current_config_response["REALTIME"]
-                if tableType is None: tableType = "REALTIME" # Default to REALTIME if only that exists
+                if tableType is None:
+                    tableType = "REALTIME"  # Default to REALTIME if only that exists
             else:
-                # Assume it's a direct config object (e.g., only one type exists and type wasn't specified in GET)
+                # Assume it's a direct config object (single table type)
                 config_to_modify = current_config_response
-                # We still need to know the type for reload later, try to infer or require it?
-                # Let's require tableType if the GET response was ambiguous (not directly a config object)
+                # Still need to know the type for reload later; infer or require it
                 if not isinstance(config_to_modify.get("tableName"), str):
-                     raise ValueError("Could not determine table config structure. Please specify tableType (OFFLINE or REALTIME).")
+                    raise ValueError(
+                        "Could not determine table config structure. Please specify "
+                        "tableType (OFFLINE or REALTIME)."
+                    )
                 if tableType is None:
                     # Infer type from tableName if possible (heuristic)
                     if config_to_modify.get("tableType") == "REALTIME":
                         tableType = "REALTIME"
                     else:
-                        tableType = "OFFLINE" # Default assumption
+                        tableType = "OFFLINE"  # Default assumption
 
             if not config_to_modify or "tableIndexConfig" not in config_to_modify:
-                 # Initialize tableIndexConfig if it doesn't exist
-                 config_to_modify["tableIndexConfig"] = {}
+                # Initialize tableIndexConfig if it doesn't exist
+                config_to_modify["tableIndexConfig"] = {}
             elif config_to_modify["tableIndexConfig"] is None:
-                 config_to_modify["tableIndexConfig"] = {}
+                config_to_modify["tableIndexConfig"] = {}
 
             index_config = config_to_modify["tableIndexConfig"]
 
@@ -364,7 +489,7 @@ class Pinot:
                 "json": "jsonIndexColumns",
                 "bloom": "bloomFilterColumns",
                 "fst": "fstIndexColumns",
-                "sorted": "sortedColumn" # Note: Only one sorted column allowed usually
+                "sorted": "sortedColumn",
             }
 
             if indexType not in index_key_map:
@@ -383,62 +508,90 @@ class Pinot:
 
             # Special handling for sortedColumn (expects single value in list)
             if config_key == "sortedColumn":
-                 if len(existing_columns) > 1:
-                      logger.warning(f"Request to add multiple sorted columns ({list(existing_columns)}). Pinot typically supports only one. Setting to the first requested column: {columns[0]}")
-                      index_config[config_key] = [columns[0]]
-                 elif len(existing_columns) == 1:
-                      index_config[config_key] = list(existing_columns)
-                 else: # No columns requested/left
-                     if config_key in index_config:
+                if len(existing_columns) > 1:
+                    logger.warning(
+                        "Request to add multiple sorted columns "
+                        f"({list(existing_columns)}). Pinot typically supports only "
+                        f"one. Setting to the first requested column: {columns[0]}"
+                    )
+                    index_config[config_key] = [columns[0]]
+                elif len(existing_columns) == 1:
+                    index_config[config_key] = list(existing_columns)
+                else:  # No columns requested/left
+                    if config_key in index_config:
                         del index_config[config_key]
             else:
                 index_config[config_key] = sorted(list(existing_columns))
 
             # 3. Update the table config via PUT
             # The PUT /tables/{tableName} expects the raw config object as the body
-            update_response = self._update_table_config(tableName, json.dumps(config_to_modify))
-            logger.info(f"Table config update response for {tableName}: {update_response}")
+            update_response = self._update_table_config(
+                tableName, json.dumps(config_to_modify)
+            )
+            logger.info(
+                f"Table config update response for {tableName}: {update_response}"
+            )
 
             # 4. Optionally trigger reload
             reload_status = "Not triggered."
             if triggerReload:
-                logger.info(f"Triggering reload for table {tableName} (type: {tableType})")
+                logger.info(
+                    f"Triggering reload for table {tableName} (type: {tableType})"
+                )
                 # Ensure tableType is determined for reload API
                 if not tableType:
-                     raise ValueError("Table type (OFFLINE/REALTIME) could not be determined for reload. Please specify.")
-                reload_response = self._reload_table_segments(tableName, tableType=tableType)
+                    raise ValueError(
+                        "Table type (OFFLINE/REALTIME) could not be determined for "
+                        "reload. Please specify."
+                    )
+                reload_response = self._reload_table_segments(
+                    tableName, tableType=tableType
+                )
                 reload_status = f"Reload triggered: {reload_response}"
                 logger.info(reload_status)
 
-            return {"status": "success", "message": f"Index '{indexType}' added to columns {columns} for table {tableName}. Config updated. {reload_status}"}
+            return {
+                "status": "success",
+                "message": (
+                    f"Index '{indexType}' added to columns {columns} for table "
+                    f"{tableName}. Config updated. {reload_status}"
+                ),
+            }
 
         except requests.exceptions.RequestException as e:
             logger.error(f"HTTP Error adding index for table {tableName}: {e}")
             return {"status": "error", "message": f"HTTP Error: {e}"}
         except ValueError as e:
-             logger.error(f"Value Error adding index for table {tableName}: {e}")
-             return {"status": "error", "message": f"Value Error: {e}"}
+            logger.error(f"Value Error adding index for table {tableName}: {e}")
+            return {"status": "error", "message": f"Value Error: {e}"}
         except Exception as e:
             logger.error(f"Unexpected error adding index for table {tableName}: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             return {"status": "error", "message": f"An unexpected error occurred: {e}"}
 
-    def _add_star_tree_index(self, tableName: str, dimensionsSplitOrder: list[str],
-                               functionColumnPairs: list[str] | None = None,
-                               aggregationConfigsJson: str | None = None,
-                               skipStarNodeCreationForDimensions: list[str] | None = None,
-                               maxLeafRecords: int = 10000,
-                               tableType: str | None = None,
-                               triggerReload: bool = True) -> dict[str, Any]:
+    def _add_star_tree_index(
+        self,
+        tableName: str,
+        dimensionsSplitOrder: list[str],
+        functionColumnPairs: list[str] | None = None,
+        aggregationConfigsJson: str | None = None,
+        skipStarNodeCreationForDimensions: list[str] | None = None,
+        maxLeafRecords: int = 10000,
+        tableType: str | None = None,
+        triggerReload: bool = True,
+    ) -> dict[str, Any]:
         """Adds a Star-Tree index configuration to a table and optionally reloads.
 
         Args:
             tableName: Name of the table.
             dimensionsSplitOrder: List of dimensions defining tree structure.
-            functionColumnPairs: List like ["SUM__colA", "COUNT__*"]. Use this OR aggregationConfigsJson.
-            aggregationConfigsJson: JSON string representing the 'aggregationConfigs' list.
-            skipStarNodeCreationForDimensions: Optional list of dimensions to skip Star-node creation.
+            functionColumnPairs: List like ["SUM__colA", "COUNT__*"]. Use this OR
+                aggregationConfigsJson.
+            aggregationConfigsJson: JSON string for the 'aggregationConfigs' list.
+            skipStarNodeCreationForDimensions: Optional list of dimensions to skip
+                Star-node creation.
             maxLeafRecords: Optional threshold for splitting nodes.
             tableType: Specify 'OFFLINE' or 'REALTIME' if needed.
             triggerReload: Whether to reload segments after update.
@@ -449,7 +602,10 @@ class Pinot:
         import json
 
         if functionColumnPairs and aggregationConfigsJson:
-            raise ValueError("Provide either functionColumnPairs or aggregationConfigsJson, not both.")
+            raise ValueError(
+                "Provide either functionColumnPairs or aggregationConfigsJson, not "
+                "both."
+            )
 
         try:
             # 1. Get current table config
@@ -457,79 +613,134 @@ class Pinot:
 
             # Determine config object to modify (similar logic as _add_index)
             config_to_modify = None
-            original_table_type = tableType # Keep track for reload
+            original_table_type = tableType  # Keep track for reload
             if tableType:
                 config_to_modify = current_config_response
             elif isinstance(current_config_response.get("OFFLINE"), dict):
                 config_to_modify = current_config_response["OFFLINE"]
-                if original_table_type is None: original_table_type = "OFFLINE"
+                if original_table_type is None:
+                    original_table_type = "OFFLINE"
             elif isinstance(current_config_response.get("REALTIME"), dict):
                 config_to_modify = current_config_response["REALTIME"]
-                if original_table_type is None: original_table_type = "REALTIME"
+                if original_table_type is None:
+                    original_table_type = "REALTIME"
             elif isinstance(current_config_response.get("tableName"), str):
                 config_to_modify = current_config_response
-                if original_table_type is None: original_table_type = config_to_modify.get("tableType", "OFFLINE")
+                if original_table_type is None:
+                    original_table_type = config_to_modify.get("tableType", "OFFLINE")
             else:
-                 raise ValueError("Could not determine table config structure. Please specify tableType (OFFLINE or REALTIME).")
+                raise ValueError(
+                    "Could not determine table config structure. Please specify "
+                    "tableType (OFFLINE or REALTIME)."
+                )
 
             # Ensure tableIndexConfig exists
-            if "tableIndexConfig" not in config_to_modify or config_to_modify["tableIndexConfig"] is None:
-                 config_to_modify["tableIndexConfig"] = {}
+            if (
+                "tableIndexConfig" not in config_to_modify
+                or config_to_modify["tableIndexConfig"] is None
+            ):
+                config_to_modify["tableIndexConfig"] = {}
             index_config = config_to_modify["tableIndexConfig"]
 
             # Ensure starTreeIndexConfigs list exists
-            if "starTreeIndexConfigs" not in index_config or index_config["starTreeIndexConfigs"] is None:
+            if (
+                "starTreeIndexConfigs" not in index_config
+                or index_config["starTreeIndexConfigs"] is None
+            ):
                 index_config["starTreeIndexConfigs"] = []
 
             # 2. Construct the new star-tree config object
             new_star_tree_config = {
                 "dimensionsSplitOrder": dimensionsSplitOrder,
-                "maxLeafRecords": maxLeafRecords
+                "maxLeafRecords": maxLeafRecords,
             }
             if skipStarNodeCreationForDimensions:
-                new_star_tree_config["skipStarNodeCreationForDimensions"] = skipStarNodeCreationForDimensions
+                new_star_tree_config["skipStarNodeCreationForDimensions"] = (
+                    skipStarNodeCreationForDimensions
+                )
 
             # Add aggregations
             if aggregationConfigsJson:
                 try:
-                    new_star_tree_config["aggregationConfigs"] = json.loads(aggregationConfigsJson)
+                    new_star_tree_config["aggregationConfigs"] = json.loads(
+                        aggregationConfigsJson
+                    )
                 except json.JSONDecodeError as json_err:
-                    raise ValueError(f"Invalid JSON provided for aggregationConfigsJson: {json_err}")
+                    raise ValueError(
+                        f"Invalid JSON provided for aggregationConfigsJson: {json_err}"
+                    )
             elif functionColumnPairs:
-                 new_star_tree_config["functionColumnPairs"] = functionColumnPairs
-            # else: No aggregations specified, which might be valid for some use cases or defaults?
+                new_star_tree_config["functionColumnPairs"] = functionColumnPairs
+            # else: No aggregations specified; defaults may apply.
 
             # 3. Append to the list
             index_config["starTreeIndexConfigs"].append(new_star_tree_config)
 
             # 4. Update the table config via PUT
-            update_response = self._update_table_config(tableName, json.dumps(config_to_modify))
-            logger.info(f"Table config update response for {tableName} (Star-Tree): {update_response}")
+            update_response = self._update_table_config(
+                tableName, json.dumps(config_to_modify)
+            )
+            logger.info(
+                "Table config update response for %s (Star-Tree): %s",
+                tableName,
+                update_response,
+            )
 
             # 5. Optionally trigger reload
-            reload_status = "Not triggered. Note: Star-Tree index creation often requires segment regeneration."
+            reload_status = (
+                "Not triggered. Note: Star-Tree index creation often requires "
+                "segment regeneration."
+            )
             if triggerReload:
-                logger.info(f"Triggering reload for table {tableName} (type: {original_table_type}) after Star-Tree config update.")
+                logger.info(
+                    "Triggering reload for table %s (type: %s) after Star-Tree "
+                    "config update.",
+                    tableName,
+                    original_table_type,
+                )
                 if not original_table_type:
-                     raise ValueError("Table type (OFFLINE/REALTIME) could not be determined for reload. Please specify.")
+                    raise ValueError(
+                        "Table type (OFFLINE/REALTIME) could not be determined for "
+                        "reload. Please specify."
+                    )
                 try:
-                    reload_response = self._reload_table_segments(tableName, tableType=original_table_type)
-                    reload_status = f"Reload triggered: {reload_response}. Note: Star-Tree index creation often requires segment regeneration."
+                    reload_response = self._reload_table_segments(
+                        tableName, tableType=original_table_type
+                    )
+                    reload_status = (
+                        f"Reload triggered: {reload_response}. Note: Star-Tree index "
+                        "creation often requires segment regeneration."
+                    )
                     logger.info(reload_status)
                 except Exception as reload_err:
-                    reload_status = f"Config updated, but failed to trigger reload: {reload_err}"
+                    reload_status = (
+                        f"Config updated, but failed to trigger reload: {reload_err}"
+                    )
                     logger.error(reload_status)
 
-            return {"status": "success", "message": f"Star-Tree index config added to table {tableName}. {reload_status}"}
+            return {
+                "status": "success",
+                "message": (
+                    f"Star-Tree index config added to table {tableName}. "
+                    f"{reload_status}"
+                ),
+            }
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"HTTP Error adding Star-Tree index for table {tableName}: {e}")
+            logger.error(
+                f"HTTP Error adding Star-Tree index for table {tableName}: {e}"
+            )
             return {"status": "error", "message": f"HTTP Error: {e}"}
         except ValueError as e:
-             logger.error(f"Value Error adding Star-Tree index for table {tableName}: {e}")
-             return {"status": "error", "message": f"Value Error: {e}"}
+            logger.error(
+                f"Value Error adding Star-Tree index for table {tableName}: {e}"
+            )
+            return {"status": "error", "message": f"Value Error: {e}"}
         except Exception as e:
-            logger.error(f"Unexpected error adding Star-Tree index for table {tableName}: {e}")
+            logger.error(
+                f"Unexpected error adding Star-Tree index for table {tableName}: {e}"
+            )
             import traceback
+
             logger.error(traceback.format_exc())
             return {"status": "error", "message": f"An unexpected error occurred: {e}"}


### PR DESCRIPTION
## Added functionality:
- **Realtime table management**: Pause/resume consumption, force commit, and check pause status
- **Table maintenance**: Reload segments, rebalance tables, and reset segments
- **Schema operations**: Create and update schemas
- **Table configuration**: Create and update table configs
- **Index management**: 
  - Add various index types (inverted, range, text, JSON, bloom, FST, sorted)
  - Support for Star-Tree indices with customizable configurations
- **Diagnostic tools**: Get consuming segments info, list supported indices

These additions significantly expand the functionality available through the API, providing operators with more granular control over Pinot deployments without needing direct access to Pinot controllers.