### PR TITLE
feat: Add PINOT_BROKER_URL configuration with override support and quickstart defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,28 @@
-# Pinot Quickstart Setup (Default)
+# Pinot Quickstart Setup (Default - uses built-in defaults if not specified)
 PINOT_CONTROLLER_URL=http://localhost:9000
-PINOT_BROKER_HOST=localhost	
-PINOT_BROKER_PORT=8000	
-PINOT_BROKER_SCHEME=http
+PINOT_BROKER_URL=http://localhost:8000
 PINOT_USE_MSQE=true
 
-# Pinot Enterprise Setup
-# PINOT_CONTROLLER_URL = "https://your-pinot-controller-url"
-# PINOT_BROKER_SCHEME = "https"
-# PINOT_BROKER_HOST = "broker.your-pinot-host"
-# PINOT_BROKER_PORT = 443
-# PINOT_USE_MSQE = true
+# Pinot Enterprise/Cloud Setup
+# PINOT_CONTROLLER_URL=https://your-pinot-controller-url
+# PINOT_BROKER_URL=https://broker.your-pinot-host:443
+# PINOT_USE_MSQE=true
 
-# PINOT_USERNAME = "your-username"
-# PINOT_PASSWORD = "your-password"
-# PINOT_TOKEN = "your-pinot-token-used-in-HTTP-Authorization-header"
-# PINOT_DATABASE = ""
+# Alternative: Individual broker configs (for advanced use cases)
+# PINOT_CONTROLLER_URL=http://localhost:9000
+# PINOT_BROKER_HOST=localhost
+# PINOT_BROKER_PORT=8000
+# PINOT_BROKER_SCHEME=http
+# PINOT_USE_MSQE=true
+
+# Override example: URL with specific port override
+# PINOT_BROKER_URL=https://broker.your-pinot-host:443
+# PINOT_BROKER_PORT=8099  # This will override the port from the URL
+
+# PINOT_USERNAME="your-username"
+# PINOT_PASSWORD="your-password"
+# PINOT_TOKEN="your-pinot-token-used-in-HTTP-Authorization-header"
+# PINOT_DATABASE=""
 
 # Timeout configurations (in seconds)
 PINOT_REQUEST_TIMEOUT=60

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,207 @@
+import os
+from unittest.mock import patch
+
+from mcp_pinot.config import _parse_broker_url, load_pinot_config
+
+
+class TestParseBrokerUrl:
+    """Test the _parse_broker_url function"""
+
+    def test_parse_full_url(self):
+        """Test parsing a full URL with all components"""
+        host, port, scheme = _parse_broker_url("https://broker.example.com:8443")
+        assert host == "broker.example.com"
+        assert port == 8443
+        assert scheme == "https"
+
+    def test_parse_url_without_port(self):
+        """Test parsing URL without explicit port uses defaults"""
+        host, port, scheme = _parse_broker_url("https://broker.example.com")
+        assert host == "broker.example.com"
+        assert port == 443  # Default for https
+        assert scheme == "https"
+
+        host, port, scheme = _parse_broker_url("http://broker.example.com")
+        assert host == "broker.example.com"
+        assert port == 80  # Default for http
+        assert scheme == "http"
+
+    def test_parse_localhost_url(self):
+        """Test parsing localhost URLs"""
+        host, port, scheme = _parse_broker_url("http://localhost:8099")
+        assert host == "localhost"
+        assert port == 8099
+        assert scheme == "http"
+
+    def test_parse_invalid_url(self):
+        """Test parsing invalid URL falls back to defaults"""
+        with patch("mcp_pinot.config.logging.warning") as mock_warning:
+            host, port, scheme = _parse_broker_url("invalid-url")
+            assert host == "localhost"
+            assert port == 80
+            assert scheme == "http"
+            mock_warning.assert_called_once()
+
+    def test_parse_url_with_path(self):
+        """Test parsing URL with path ignores the path"""
+        host, port, scheme = _parse_broker_url("https://broker.example.com:8443/some/path")
+        assert host == "broker.example.com"
+        assert port == 8443
+        assert scheme == "https"
+
+
+class TestLoadPinotConfig:
+    """Test the load_pinot_config function"""
+
+    def test_individual_configs_only(self):
+        """Test loading config with only individual broker configs"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_HOST": "broker.example.com",
+            "PINOT_BROKER_PORT": "8099",
+            "PINOT_BROKER_SCHEME": "http",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.broker_host == "broker.example.com"
+                assert config.broker_port == 8099
+                assert config.broker_scheme == "http"
+
+    def test_broker_url_only(self):
+        """Test loading config with only PINOT_BROKER_URL"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_URL": "https://broker.example.com:8443",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.broker_host == "broker.example.com"
+                assert config.broker_port == 8443
+                assert config.broker_scheme == "https"
+
+    def test_broker_url_with_individual_overrides(self):
+        """Test that individual configs override URL values"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_URL": "https://broker.example.com:8443",
+            "PINOT_BROKER_HOST": "override.example.com",
+            "PINOT_BROKER_PORT": "9000",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch("mcp_pinot.config.logging.warning") as mock_warning:
+                with patch.dict(os.environ, env_vars, clear=True):
+                    config = load_pinot_config()
+                    assert config.broker_host == "override.example.com"
+                    assert config.broker_port == 9000
+                    assert config.broker_scheme == "https"  # From URL, not overridden
+
+                    # Should warn about overrides
+                    assert mock_warning.call_count == 2
+                    warning_calls = [
+                        call.args[0] for call in mock_warning.call_args_list
+                    ]
+                    assert any("PINOT_BROKER_HOST" in call for call in warning_calls)
+                    assert any("PINOT_BROKER_PORT" in call for call in warning_calls)
+
+    def test_broker_url_with_scheme_override(self):
+        """Test that PINOT_BROKER_SCHEME overrides URL scheme"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_URL": "https://broker.example.com:8443",
+            "PINOT_BROKER_SCHEME": "http",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch("mcp_pinot.config.logging.warning") as mock_warning:
+                with patch.dict(os.environ, env_vars, clear=True):
+                    config = load_pinot_config()
+                    assert config.broker_host == "broker.example.com"
+                    assert config.broker_port == 8443
+                    assert config.broker_scheme == "http"  # Overridden
+
+                    # Should warn about scheme override
+                    mock_warning.assert_called_once()
+                    assert "PINOT_BROKER_SCHEME" in mock_warning.call_args[0][0]
+
+    def test_no_broker_config(self):
+        """Test default values when no broker config is provided"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.controller_url == "http://controller:9000"
+                assert config.broker_host == "localhost"
+                assert config.broker_port == 8000
+                assert config.broker_scheme == "http"
+
+    def test_quickstart_defaults(self):
+        """Test that quickstart defaults are used when no config is provided"""
+        env_vars = {}  # No config at all
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.controller_url == "http://localhost:9000"
+                assert config.broker_host == "localhost"
+                assert config.broker_port == 8000
+                assert config.broker_scheme == "http"
+
+    def test_broker_url_default_ports(self):
+        """Test that URL parsing uses correct default ports"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_URL": "http://broker.example.com",  # No port specified
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.broker_host == "broker.example.com"
+                assert config.broker_port == 80  # Default for http
+                assert config.broker_scheme == "http"
+
+        # Test HTTPS default
+        env_vars["PINOT_BROKER_URL"] = "https://broker.example.com"
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.broker_port == 443  # Default for https
+
+    def test_all_config_fields_present(self):
+        """Test that all expected config fields are present"""
+        env_vars = {
+            "PINOT_CONTROLLER_URL": "http://controller:9000",
+            "PINOT_BROKER_URL": "https://broker.example.com:8443",
+            "PINOT_USERNAME": "testuser",
+            "PINOT_PASSWORD": "testpass",
+            "PINOT_TOKEN": "testtoken",
+            "PINOT_DATABASE": "testdb",
+            "PINOT_USE_MSQE": "true",
+            "PINOT_REQUEST_TIMEOUT": "30",
+            "PINOT_CONNECTION_TIMEOUT": "20",
+            "PINOT_QUERY_TIMEOUT": "40",
+        }
+
+        with patch("mcp_pinot.config.load_dotenv"):  # Disable .env loading
+            with patch.dict(os.environ, env_vars, clear=True):
+                config = load_pinot_config()
+                assert config.controller_url == "http://controller:9000"
+                assert config.broker_host == "broker.example.com"
+                assert config.broker_port == 8443
+                assert config.broker_scheme == "https"
+                assert config.username == "testuser"
+                assert config.password == "testpass"
+                assert config.token == "testtoken"
+                assert config.database == "testdb"
+                assert config.use_msqe is True
+                assert config.request_timeout == 30
+                assert config.connection_timeout == 20
+                assert config.query_timeout == 40

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,8 +198,8 @@ class TestLoadPinotConfig:
                 assert config.broker_port == 8443
                 assert config.broker_scheme == "https"
                 assert config.username == "testuser"
-                assert config.password == "testpass"
-                assert config.token == "testtoken"
+                assert config.password == "testpass"  # noqa: S105
+                assert config.token == "testtoken"  # noqa: S105
                 assert config.database == "testdb"
                 assert config.use_msqe is True
                 assert config.request_timeout == 30

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,7 +44,9 @@ class TestParseBrokerUrl:
 
     def test_parse_url_with_path(self):
         """Test parsing URL with path ignores the path"""
-        host, port, scheme = _parse_broker_url("https://broker.example.com:8443/some/path")
+        host, port, scheme = _parse_broker_url(
+            "https://broker.example.com:8443/some/path"
+        )
         assert host == "broker.example.com"
         assert port == 8443
         assert scheme == "https"


### PR DESCRIPTION
## Summary

This PR consolidates Pinot broker configuration by introducing `PINOT_BROKER_URL` as a convenient single-URL configuration option while maintaining backward compatibility with individual broker config fields. It also updates default values to match Pinot quickstart setup.

## Key Changes

### 🆕 **New PINOT_BROKER_URL Configuration**
- Added support for `PINOT_BROKER_URL` (e.g., `http://localhost:8000`)
- URL is parsed to extract host, port, and scheme automatically
- Individual configs (`PINOT_BROKER_HOST`, `PINOT_BROKER_PORT`, `PINOT_BROKER_SCHEME`) can override URL values
- Warning messages logged when individual configs override URL values

### 🔧 **Updated Quickstart Defaults**
- **Controller**: Now defaults to `http://localhost:9000` (was empty)
- **Broker**: Now defaults to `http://localhost:8000` (was `https://localhost:443`)
- These match the Docker quickstart command in the README

### 📚 **Documentation Updates**
- Updated `.env.example` to showcase `PINOT_BROKER_URL` as the primary configuration method
- Reorganized examples to show quickstart vs enterprise configurations
- Individual broker configs moved to "advanced use cases" section

### ✅ **Configuration Priority**
1. Individual configs (`PINOT_BROKER_HOST`, `PINOT_BROKER_PORT`, `PINOT_BROKER_SCHEME`) - highest priority
2. Values parsed from `PINOT_BROKER_URL` - used as defaults
3. Built-in quickstart defaults - lowest priority

## Examples

**Quickstart (minimal config):**
```bash
# Uses built-in defaults if not specified
PINOT_CONTROLLER_URL=http://localhost:9000
PINOT_BROKER_URL=http://localhost:8000
```

**Enterprise/Cloud:**
```bash
PINOT_CONTROLLER_URL=https://your-controller-url
PINOT_BROKER_URL=https://broker.example.com:443
PINOT_USERNAME=your_username
PINOT_TOKEN=your_token
```

**Override example:**
```bash
PINOT_BROKER_URL=https://broker.example.com:443
PINOT_BROKER_PORT=8099  # This overrides the port from the URL
```

## Test Coverage

- Added comprehensive test suite (`tests/test_config.py`) with 13 test cases
- Tests cover URL parsing, override behavior, default values, and error handling
- All existing tests continue to pass

## Backward Compatibility

✅ **Fully backward compatible** - existing configurations continue to work unchanged.

## Benefits

- **Simplified Configuration**: Single URL instead of three separate values
- **Better UX**: Matches how most tools handle URL-based configuration  
- **Zero Config for Quickstart**: Works out-of-the-box with Pinot quickstart Docker command
- **Flexible**: Advanced users can still use individual configs or selective overrides