### PR TITLE
Add index update tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It allows you to
 - List tables, segments, and schema info from Pinot
 - Execute read-only SQL queries
 - View index/column-level metadata
+- Modify table configurations, including adding indexes
 - Designed to assist business users via Claude integration
 - and much more.
 

--- a/mcp_pinot/prompts.py
+++ b/mcp_pinot/prompts.py
@@ -36,6 +36,7 @@ You have access to the following tools to assist in your analysis:
 6. segment-list: List all segments for a specific table
 7. segment-metadata-details: Get metadata details for a specific segment
 8. tableconfig-schema-details: Get combined table configuration and schema details
+9. add-index: Add an index to a table configuration
 
 When a user provides a query, follow these steps:
 

--- a/mcp_pinot/server.py
+++ b/mcp_pinot/server.py
@@ -212,6 +212,20 @@ async def main():
                     "required": ["tableName"],
                 },
             ),
+            types.Tool(
+                name="add-index",
+                description="Add an index to a table configuration",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "tableName": {"type": "string"},
+                        "tableType": {"type": "string"},
+                        "columnName": {"type": "string"},
+                        "indexType": {"type": "string"},
+                    },
+                    "required": ["tableName", "tableType", "columnName", "indexType"],
+                },
+            ),
         ]
 
     @server.call_tool()
@@ -299,6 +313,15 @@ async def main():
                 results = pinot_client.get_table_config(
                     tableName=arguments["tableName"],
                     tableType=arguments.get("tableType"),
+                )
+                return [types.TextContent(type="text", text=str(results))]
+
+            elif name == "add-index":
+                results = pinot_client.add_index_to_table_config(
+                    tableName=arguments["tableName"],
+                    tableType=arguments["tableType"],
+                    columnName=arguments["columnName"],
+                    indexType=arguments["indexType"],
                 )
                 return [types.TextContent(type="text", text=str(results))]
 


### PR DESCRIPTION
## Summary
- add `add_index_to_table_config` helper on `PinotClient`
- expose new `add-index` tool in the MCP server
- document new tool in prompt template and README
- test index update helper

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_685eb3340cb083249206e93c4fb20ebd