### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,8 +29,8 @@ jobs:
     
     - name: Run ruff check
       run: |
-        ruff check .
+        uvx ruff check .
     
     - name: Run ruff format check
       run: |
-        ruff format --check .
+        uvx ruff format --check .


### PR DESCRIPTION
This pull request updates the `.github/workflows/lint.yml` file to use `uvx` for running `ruff` commands instead of directly invoking `ruff`.