### PR TITLE
ci: Fix lint workflow to use uv run for ruff commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,8 +29,8 @@ jobs:
     
     - name: Run ruff check
       run: |
-        ruff check .
+        uv run ruff check .
     
     - name: Run ruff format check
       run: |
-        ruff format --check .
+        uv run ruff format --check .


### PR DESCRIPTION
## Summary

Fixes the lint workflow to use `uv run` for ruff commands instead of calling ruff directly.

## Changes

- Updated `.github/workflows/lint.yml` to use `uv run ruff check .` instead of `ruff check .`
- Updated `.github/workflows/lint.yml` to use `uv run ruff format --check .` instead of `ruff format --check .`

This ensures that ruff is run within the proper uv environment context, which is consistent with how the project is configured to use uv as the package manager.

## Test Plan

- [x] Lint workflow should now pass in CI
- [x] Commands work locally with uv environment