### PR TITLE
fix: redirect logging to stderr for stdio transport compatibility

### DIFF
--- a/mcp_pinot/config.py
+++ b/mcp_pinot/config.py
@@ -15,7 +15,7 @@ def setup_logging():
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        stream=sys.stdout,
+        stream=sys.stderr,
         force=True,
     )
 


### PR DESCRIPTION
## Summary
- Redirect logging output from `stdout` to `stderr` in `config.py` to fix MCP stdio transport compatibility
- In stdio mode, `stdout` is reserved for JSON-RPC protocol messages; logging to `stdout` causes the client to fail with `Unexpected non-whitespace character after JSON` parse errors

## Test plan
- Verified MCP server connects successfully via stdio transport after the change
- Confirmed logging output appears in Cursor's MCP error panel (stderr) without interfering with protocol communication