### PR TITLE
ci: publish PyPI and MCP registry releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,118 @@
+name: Publish PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to publish, for example v3.1.0"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release-tag:
+        description: "Release tag to publish, for example v3.1.0"
+        required: true
+        type: string
+    secrets:
+      PYPI_TOKEN:
+        required: true
+
+env:
+  PYTHON_PACKAGE_NAME: mcp-pinot-server
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout release tag
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.release-tag }}
+        fetch-depth: 0
+
+    - name: Validate release tag
+      env:
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        case "$RELEASE_TAG" in
+          v*) ;;
+          *)
+            echo "Release tag must start with 'v', got '$RELEASE_TAG'." >&2
+            exit 1
+            ;;
+        esac
+
+        git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+        TAG_COMMIT=$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")
+        HEAD_COMMIT=$(git rev-parse HEAD)
+        if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+          echo "Checked-out ref does not match $RELEASE_TAG." >&2
+          echo "tag:  $TAG_COMMIT" >&2
+          echo "head: $HEAD_COMMIT" >&2
+          exit 1
+        fi
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install build tooling
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build packaging twine
+
+    - name: Validate PyPI token
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        if [ -z "$PYPI_TOKEN" ]; then
+          echo "PYPI_TOKEN repository secret is required to publish to PyPI." >&2
+          exit 1
+        fi
+
+    - name: Set package version from tag
+      env:
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        python - <<'PY'
+        from pathlib import Path
+        import os
+        import re
+
+        from packaging.version import InvalidVersion, Version
+
+        raw_version = os.environ["RELEASE_TAG"]
+        candidate = raw_version[1:] if raw_version.startswith("v") else raw_version
+        try:
+            package_version = str(Version(candidate))
+        except InvalidVersion as exc:
+            raise SystemExit(f"Release tag {raw_version!r} is not a valid PyPI version: {exc}") from exc
+
+        path = Path("pyproject.toml")
+        text = path.read_text()
+        updated, count = re.subn(
+            r'(?m)^version = "[^"]+"$',
+            f'version = "{package_version}"',
+            text,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit("Expected exactly one project version in pyproject.toml")
+        path.write_text(updated)
+        print(f"Set Python package version to {package_version}")
+        PY
+
+    - name: Build Python package
+      run: |
+        python -m build
+        python -m twine check dist/*
+
+    - name: Publish Python package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: startreedata/mcp-pinot
+  PYTHON_PACKAGE_NAME: mcp-pinot-server
+  MCP_REGISTRY_NAME: io.github.startreedata/mcp-pinot
 
 permissions: {}
 
@@ -22,18 +24,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-    
+
     - name: Run tests
       run: |
         pytest tests/ --cov=mcp_pinot --cov-report=xml
@@ -82,8 +84,18 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+  publish-pypi:
+    needs: [test]
+    uses: ./.github/workflows/publish-pypi.yml
+    permissions:
+      contents: read
+    with:
+      release-tag: ${{ github.ref_name }}
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
   create-release:
-    needs: [test, build-and-push]
+    needs: [test, build-and-push, publish-pypi]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -126,11 +138,11 @@ jobs:
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
         echo "Updating Chart.yaml version to: $VERSION"
-        
+
         # Update Chart.yaml with the Git tag version
         sed -i "s/^version: .*/version: $VERSION/" ./helm/mcp-pinot/Chart.yaml
         sed -i "s/^appVersion: .*/appVersion: \"$VERSION\"/" ./helm/mcp-pinot/Chart.yaml
-        
+
         # Verify the changes
         echo "Updated Chart.yaml:"
         cat ./helm/mcp-pinot/Chart.yaml
@@ -150,10 +162,10 @@ jobs:
       run: |
         CHART_VERSION=${GITHUB_REF#refs/tags/}
         echo "Pushing Helm chart with version: $CHART_VERSION"
-        
+
         # Push to GHCR OCI registry
         helm push ./helm-packages/mcp-pinot-*.tgz oci://ghcr.io/${{ github.repository }}/charts
-        
+
         echo "Helm chart pushed to ghcr.io/${{ github.repository }}/charts/mcp-pinot:$CHART_VERSION"
 
     - name: Generate changelog
@@ -161,7 +173,7 @@ jobs:
       run: |
         # Get the previous tag
         PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1)
-        
+
         # Generate changelog content
         CHANGELOG="## Changes since $PREVIOUS_TAG"
         CHANGELOG="$CHANGELOG\n\n"
@@ -181,44 +193,154 @@ jobs:
         name: Release ${{ github.ref_name }}
         body: |
           ${{ steps.changelog.outputs.changelog }}
-          
+
           ## Docker Image
-          
+
           The Docker image is available at:
           ```
           ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           ```
-          
+
           ## DXT Package
-          
+
           Download the `.dxt` file for Claude Desktop integration.
-          
+
           ## Helm Chart
-          
+
           The Helm chart is available from GHCR OCI Registry:
           ```bash
           helm install mcp-pinot oci://ghcr.io/${{ github.repository }}/charts/mcp-pinot
+          ```
+
+          ## PyPI Package
+
+          The Python package is available at:
+          ```bash
+          pip install ${{ env.PYTHON_PACKAGE_NAME }}
           ```
         files: |
           *.dxt
         draft: false
         prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
 
+  publish-mcp-registry:
+    needs: [publish-pypi, create-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install version tooling
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install packaging
+
+    - name: Set MCP Registry version from tag
+      id: versions
+      env:
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: |
+        python - <<'PY'
+        from pathlib import Path
+        import json
+        import os
+
+        from packaging.version import InvalidVersion, Version
+
+        raw_version = os.environ["RELEASE_TAG"]
+        server_version = raw_version[1:] if raw_version.startswith("v") else raw_version
+        try:
+            package_version = str(Version(server_version))
+        except InvalidVersion as exc:
+            raise SystemExit(f"Release tag {raw_version!r} is not a valid PyPI version: {exc}") from exc
+
+        path = Path("server.json")
+        metadata = json.loads(path.read_text())
+        metadata["version"] = server_version
+        for package in metadata.get("packages", []):
+            if package.get("registryType") == "pypi":
+                package["version"] = package_version
+        path.write_text(json.dumps(metadata, indent=2) + "\n")
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+            print(f"server_version={server_version}", file=output)
+            print(f"package_version={package_version}", file=output)
+        print(f"Set MCP Registry version to {server_version}")
+        print(f"Set PyPI package version to {package_version}")
+        PY
+
+    - name: Wait for PyPI package metadata
+      env:
+        PACKAGE_NAME: ${{ env.PYTHON_PACKAGE_NAME }}
+        PACKAGE_VERSION: ${{ steps.versions.outputs.package_version }}
+      run: |
+        python - <<'PY'
+        import json
+        import os
+        import time
+        import urllib.error
+        import urllib.request
+
+        package_name = os.environ["PACKAGE_NAME"]
+        package_version = os.environ["PACKAGE_VERSION"]
+        url = f"https://pypi.org/pypi/{package_name}/json"
+
+        for attempt in range(1, 11):
+            try:
+                with urllib.request.urlopen(url, timeout=20) as response:
+                    versions = json.load(response).get("releases", {})
+                if package_version in versions:
+                    print(f"Found {package_name} {package_version} on PyPI")
+                    break
+            except (urllib.error.URLError, TimeoutError) as exc:
+                print(f"PyPI metadata attempt {attempt} failed: {exc}")
+            if attempt == 10:
+                raise SystemExit(f"{package_name} {package_version} was not visible on PyPI")
+            time.sleep(15)
+        PY
+
+    - name: Install mcp-publisher
+      run: |
+        curl --fail --location --silent --show-error --retry 3 --retry-delay 5 --connect-timeout 30 --max-time 120 \
+          "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+          | tar xz mcp-publisher
+        ./mcp-publisher --help
+
+    - name: Authenticate to MCP Registry
+      run: ./mcp-publisher login github-oidc
+
+    - name: Publish to MCP Registry
+      run: ./mcp-publisher publish
+
   notify:
-    needs: [create-release]
+    needs: [publish-pypi, build-and-push, create-release, publish-mcp-registry]
     runs-on: ubuntu-latest
     permissions: {}
     if: always()
     steps:
     - name: Notify on success
-      if: needs.create-release.result == 'success'
+      if: needs.publish-pypi.result == 'success' && needs.build-and-push.result == 'success' && needs.create-release.result == 'success' && needs.publish-mcp-registry.result == 'success'
       run: |
         echo "✅ Release ${{ github.ref_name }} created successfully!"
         echo "🐳 Docker image published to ghcr.io/${{ github.repository }}:${{ github.ref_name }}"
+        echo "🐍 PyPI package published to https://pypi.org/project/${{ env.PYTHON_PACKAGE_NAME }}/"
+        echo "🧩 MCP Registry entry published as ${{ env.MCP_REGISTRY_NAME }}"
         echo "📦 Release available at https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
 
     - name: Notify on failure
-      if: needs.create-release.result == 'failure'
+      if: needs.publish-pypi.result != 'success' || needs.build-and-push.result != 'success' || needs.create-release.result != 'success' || needs.publish-mcp-registry.result != 'success'
       run: |
         echo "❌ Release creation failed!"
+        echo "publish-pypi: ${{ needs.publish-pypi.result }}"
+        echo "build-and-push: ${{ needs.build-and-push.result }}"
+        echo "create-release: ${{ needs.create-release.result }}"
+        echo "publish-mcp-registry: ${{ needs.publish-mcp-registry.result }}"
         exit 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Pinot MCP Server
+<!-- mcp-name: io.github.startreedata/mcp-pinot -->
 
 ## Table of Contents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "mcp-pinot-server"
 version = "0.1.0"
 description = "A production-grade MCP server for Apache Pinot"
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.startreedata/mcp-pinot",
+  "title": "Apache Pinot MCP Server",
+  "description": "Explore and query Apache Pinot clusters through MCP.",
+  "repository": {
+    "url": "https://github.com/startreedata/mcp-pinot",
+    "source": "github"
+  },
+  "websiteUrl": "https://startreedata.github.io/mcp-pinot/",
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "mcp-pinot-server",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PINOT_CONTROLLER_URL",
+          "description": "HTTP(S) endpoint of the Pinot Controller.",
+          "format": "string",
+          "default": "http://localhost:9000"
+        },
+        {
+          "name": "PINOT_BROKER_URL",
+          "description": "HTTP(S) endpoint of the Pinot Broker.",
+          "format": "string",
+          "default": "http://localhost:8000"
+        },
+        {
+          "name": "PINOT_USERNAME",
+          "description": "Optional Pinot basic-auth username.",
+          "format": "string"
+        },
+        {
+          "name": "PINOT_PASSWORD",
+          "description": "Optional Pinot basic-auth password.",
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "PINOT_TOKEN",
+          "description": "Optional Pinot bearer token. Overrides username and password when set.",
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "PINOT_USE_MSQE",
+          "description": "Whether to enable Pinot multi-stage query engine support.",
+          "format": "boolean",
+          "default": "true"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a standalone `Publish PyPI` workflow that can be run manually with a `release-tag` input such as `v3.1.0`
- wire the normal tag `Release` workflow to call that reusable PyPI workflow after tests, before GitHub release and MCP Registry publication
- add MCP Registry metadata in `server.json` and publish it with `mcp-publisher` after PyPI and GitHub release publication
- add the MCP ownership marker to the PyPI README metadata and expose `README.md` as the package long description

## Release flow

A `v*` tag release now runs tests, invokes `.github/workflows/publish-pypi.yml` with the tag name, publishes Docker/Helm/DXT as before, waits until the released PyPI version is visible in PyPI metadata, then publishes `io.github.startreedata/mcp-pinot` to the MCP Registry using GitHub OIDC.

The PyPI step can also be run directly from GitHub Actions via `Publish PyPI` by supplying a release tag. The workflow checks out that exact tag, verifies it resolves to the checked-out commit, derives the PEP 440 package version from the tag, builds the package, runs `twine check`, and publishes with `PYPI_TOKEN`.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/publish-pypi.yml`
- `server.json` validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- `python -m build && python -m twine check dist/*`
- `pytest tests/` (`172 passed, 7 skipped`)
