### PR TITLE
fix: correct package version to 3.2.0 (regressed to 0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-16
+## [3.2.0] - 2026-06-16
 
 ### Breaking Changes
 - Tool results are now **structured** (typed `outputSchema` + `structuredContent`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-pinot-server"
-version = "0.2.0"
+version = "3.2.0"
 description = "A production-grade MCP server for Apache Pinot"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What
Corrects the package version from `0.2.0` back onto the release line as **`3.2.0`** (and renames the matching CHANGELOG heading). No code changes.

## Why
PyPI `mcp-pinot-server` is at **3.1.0** and GitHub releases run `v1.0.0 → v3.1.0`, but #100 set `pyproject.toml` `version = "0.2.0"`. A `0.2.0` publish would be rejected as older than `3.1.0`, **blocking the next release**. This bumps to `3.2.0` (next minor) so the release pipeline is unblocked.

## Risk
None — version string + changelog heading only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)