### PR TITLE
feat(mcp): expose catalog resources + an explore_table prompt

### DIFF
--- a/mcp_pinot/server.py
+++ b/mcp_pinot/server.py
@@ -648,6 +648,52 @@ def pinot_query() -> str:
     return PROMPT_TEMPLATE.strip()
 
 
+@mcp.prompt
+def explore_table(table_name: str) -> str:
+    """Guide a structured exploration of a single Pinot table.
+
+    Args:
+        table_name: The Pinot table to explore (case-sensitive).
+    """
+    return (
+        f"Help me explore the Pinot table '{table_name}'.\n"
+        f"1. Call get_schema and get_table_config for '{table_name}' to learn its "
+        f"columns, types, and time column.\n"
+        f"2. Call table_details and segment_list for its size and segment layout.\n"
+        f"3. Run read_query with a small LIMIT (e.g. 10) to sample rows from "
+        f"'{table_name}'.\n"
+        f"4. Summarize the table's purpose, key dimensions/metrics, and time range."
+    )
+
+
+@mcp.resource("pinot://tables", mime_type="application/json")
+def tables_resource() -> str:
+    """The Pinot tables visible to this server (honors table filters)."""
+    tables = _call("tables_resource", _HINT_READ, pinot_client.get_tables)
+    return json.dumps({"tables": tables})
+
+
+@mcp.resource("pinot://schema/{schema_name}", mime_type="application/json")
+def schema_resource(schema_name: str) -> str:
+    """The Pinot schema definition for a given schema name."""
+    raw = _call(
+        "schema_resource", _HINT_READ, pinot_client.get_schema, schemaName=schema_name
+    )
+    return json.dumps(raw)
+
+
+@mcp.resource("pinot://table-config/{table_name}", mime_type="application/json")
+def table_config_resource(table_name: str) -> str:
+    """The Pinot table configuration for a given table name."""
+    raw = _call(
+        "table_config_resource",
+        _HINT_READ,
+        pinot_client.get_table_config,
+        tableName=table_name,
+    )
+    return json.dumps(raw)
+
+
 def main():
     """Main entry point for FastMCP Pinot Server"""
     tls_enabled = server_config.ssl_keyfile and server_config.ssl_certfile

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -129,6 +129,42 @@ class TestFastMCPServer:
         )
 
     @pytest.mark.asyncio
+    async def test_explore_table_prompt_renders(self):
+        """The explore_table prompt renders with the provided table name."""
+        async with Client(mcp) as client:
+            result = await client.get_prompt("explore_table", {"table_name": "orders"})
+        text = " ".join(
+            m.content.text for m in result.messages if hasattr(m.content, "text")
+        )
+        assert "orders" in text
+
+    @pytest.mark.asyncio
+    async def test_resources_registered(self, mock_pinot_client):
+        """Catalog resources are registered (static + templated)."""
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            templates = await client.list_resource_templates()
+        static_uris = {str(r.uri) for r in resources}
+        template_uris = {t.uriTemplate for t in templates}
+        assert "pinot://tables" in static_uris
+        assert any("pinot://schema/" in u for u in template_uris)
+        assert any("pinot://table-config/" in u for u in template_uris)
+
+    @pytest.mark.asyncio
+    async def test_read_tables_and_schema_resources(self, mock_pinot_client):
+        """The static and templated resources read through to the client."""
+        async with Client(mcp) as client:
+            tables = await client.read_resource("pinot://tables")
+            schema = await client.read_resource("pinot://schema/test_table")
+            config = await client.read_resource("pinot://table-config/test_table")
+        tables_text = " ".join(c.text for c in tables if hasattr(c, "text"))
+        schema_text = " ".join(c.text for c in schema if hasattr(c, "text"))
+        config_text = " ".join(c.text for c in config if hasattr(c, "text"))
+        assert "test_table" in tables_text
+        assert "schema" in schema_text
+        assert "config" in config_text
+
+    @pytest.mark.asyncio
     async def test_tool_test_connection(self, mock_pinot_client):
         """test_connection returns typed diagnostics."""
         async with Client(mcp) as client:


### PR DESCRIPTION
## Why
Lifts the arcade Trust Report's **Protocol Readiness** dimension by adding the MCP advanced features it rewards — `resources` and additional `prompts`. (Tool annotations, the other Protocol-Readiness item, already shipped in #100.) All additions are **read-only and additive**.

## What
- **Resources** (backed by existing `PinotClient` read methods, returned as JSON):
  - `pinot://tables` — tables visible to this server (honors filters)
  - `pinot://schema/{schema_name}` — a schema definition
  - `pinot://table-config/{table_name}` — a table configuration
- **Prompt**: `explore_table(table_name)` — a structured table-exploration guide, alongside the existing `pinot_query`.

## Non-breaking
Pure additions — no existing tool/prompt changed. Gate green locally: ruff + format + mypy clean, **202 passed / 7 skipped**, coverage **90%** (gate 85%).

## Tests
Resource registration (static + templated), reading each of the three resources through to the client, and `explore_table` prompt rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)