### PR TITLE
chore: add SUPPORT.md, issue templates, and README badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with the Pinot MCP server
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please do **not** include
+        secrets (tokens, passwords, connection strings) in this report.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, including the tool/query you called.
+      placeholder: |
+        1. Configure ...
+        2. Call tool ...
+        3. See error ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: mcp-pinot-server version
+      placeholder: e.g. 3.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - http
+        - https
+    validations:
+      required: true
+  - type: input
+    id: pinot-version
+    attributes:
+      label: Apache Pinot version
+      placeholder: e.g. 1.2.0
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output (redact secrets).
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/startreedata/mcp-pinot/security/policy
+    about: Please report security issues privately, not as public issues.
+  - name: Documentation
+    url: https://github.com/startreedata/mcp-pinot/blob/main/README.md
+    about: Installation, configuration, and usage documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an enhancement for the Pinot MCP server
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, tool, or API you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Pinot MCP Server
 <!-- mcp-name: io.github.startreedata/mcp-pinot -->
 
+[![Build and Test](https://github.com/startreedata/mcp-pinot/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/startreedata/mcp-pinot/actions/workflows/build-and-test.yml)
+[![PyPI version](https://img.shields.io/pypi/v/mcp-pinot-server.svg)](https://pypi.org/project/mcp-pinot-server/)
+[![Python versions](https://img.shields.io/pypi/pyversions/mcp-pinot-server.svg)](https://pypi.org/project/mcp-pinot-server/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+Thanks for using the Apache Pinot MCP Server! Here's how to get help.
+
+## Documentation
+
+Start with the [README](README.md) — it covers installation, configuration
+(environment variables), transports (stdio / HTTP / HTTPS), authentication, and
+the available tools, resources, and prompts.
+
+## Questions, bugs, and feature requests
+
+Open a [GitHub issue](https://github.com/startreedata/mcp-pinot/issues/new/choose):
+
+- **Bug report** — include your package version, transport (stdio/HTTP), Pinot
+  version, and steps to reproduce.
+- **Feature request** — describe the use case and the behavior you'd like.
+
+Please do **not** include secrets (tokens, passwords, connection strings) in
+issues.
+
+## Security
+
+Please **do not** open public issues for vulnerabilities. Follow the private
+process described in [SECURITY.md](SECURITY.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the quality
+gates (ruff, mypy, and pytest with ≥ 85% coverage).


### PR DESCRIPTION
## Why
Improves the arcade Trust Report's **Supportability** dimension with the documentation/governance signals it looks for. **Docs-only** — no code or CI behavior changes.

## What
- **SUPPORT.md** — where to find docs, file bugs/features, and report security issues.
- **.github/ISSUE_TEMPLATE/** — structured **bug report** and **feature request** forms, plus a `config.yml` that routes security reports to the private policy and disables blank issues.
- **README badges** — CI status, PyPI version, supported Python versions, and license.

## Notes
- `CODEOWNERS` was intentionally **not** added — it needs the maintainers' real team/handle, and a wrong owner is worse than none. Happy to add it if you share the right team slug.
- Issue-form YAML validated locally; `ruff` clean (no Python changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)