### PR TITLE
feat: arcade Trust Report improvements for v3.2.0 (schemas, resources, supportability)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with the Pinot MCP server
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please do **not** include
+        secrets (tokens, passwords, connection strings) in this report.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, including the tool/query you called.
+      placeholder: |
+        1. Configure ...
+        2. Call tool ...
+        3. See error ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: mcp-pinot-server version
+      placeholder: e.g. 3.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - http
+        - https
+    validations:
+      required: true
+  - type: input
+    id: pinot-version
+    attributes:
+      label: Apache Pinot version
+      placeholder: e.g. 1.2.0
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output (redact secrets).
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/startreedata/mcp-pinot/security/policy
+    about: Please report security issues privately, not as public issues.
+  - name: Documentation
+    url: https://github.com/startreedata/mcp-pinot/blob/main/README.md
+    about: Installation, configuration, and usage documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an enhancement for the Pinot MCP server
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, tool, or API you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Documented output schemas for the inspection tools (`table_details`,
+  `segment_list`, `index_column_details`, `segment_metadata_details`,
+  `tableconfig_schema_details`, `get_schema`, `get_table_config`) via typed
+  Pydantic models, so every tool advertises a documented `outputSchema`. Extra
+  fields are preserved (`extra="allow"`), so response shapes are unchanged.
+- The schema/table-config write tools (`create_schema`, `update_schema`,
+  `create_table_config`, `update_table_config`) now accept their JSON payload as
+  a structured object **or** a JSON string (back-compatible), giving clients a
+  real input schema for the payload.
+
 ## [0.2.0] - 2026-06-16
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-16
+## [3.2.0] - 2026-06-16
 
 ### Breaking Changes
 - Tool results are now **structured** (typed `outputSchema` + `structuredContent`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Pinot MCP Server
 <!-- mcp-name: io.github.startreedata/mcp-pinot -->
 
+[![Build and Test](https://github.com/startreedata/mcp-pinot/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/startreedata/mcp-pinot/actions/workflows/build-and-test.yml)
+[![PyPI version](https://img.shields.io/pypi/v/mcp-pinot-server.svg)](https://pypi.org/project/mcp-pinot-server/)
+[![Python versions](https://img.shields.io/pypi/pyversions/mcp-pinot-server.svg)](https://pypi.org/project/mcp-pinot-server/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+Thanks for using the Apache Pinot MCP Server! Here's how to get help.
+
+## Documentation
+
+Start with the [README](README.md) — it covers installation, configuration
+(environment variables), transports (stdio / HTTP / HTTPS), authentication, and
+the available tools, resources, and prompts.
+
+## Questions, bugs, and feature requests
+
+Open a [GitHub issue](https://github.com/startreedata/mcp-pinot/issues/new/choose):
+
+- **Bug report** — include your package version, transport (stdio/HTTP), Pinot
+  version, and steps to reproduce.
+- **Feature request** — describe the use case and the behavior you'd like.
+
+Please do **not** include secrets (tokens, passwords, connection strings) in
+issues.
+
+## Security
+
+Please **do not** open public issues for vulnerabilities. Follow the private
+process described in [SECURITY.md](SECURITY.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the quality
+gates (ruff, mypy, and pytest with ≥ 85% coverage).

--- a/mcp_pinot/models.py
+++ b/mcp_pinot/models.py
@@ -113,3 +113,137 @@ class OperationResult(BaseModel):
     message: str | None = Field(
         default=None, description="Human-readable detail, when provided."
     )
+
+
+class TableSizeDetails(BaseModel):
+    """Storage size for a table (Pinot ``GET /tables/{name}/size``).
+
+    Declared fields document the common size metrics; any additional fields Pinot
+    returns (per-segment breakdowns, etc.) are preserved.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tableName: str | None = Field(default=None, description="The table name.")
+    reportedSizeInBytes: int | None = Field(
+        default=None,
+        description="Size reported by the servers currently hosting the table's "
+        "segments, in bytes.",
+    )
+    estimatedSizeInBytes: int | None = Field(
+        default=None,
+        description="Estimated size assuming every replica is present, in bytes.",
+    )
+
+
+class SegmentList(BaseModel):
+    """Segment names for a table, grouped by table type."""
+
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: Any) -> Any:
+        # Some Pinot versions return a list of single-key maps, e.g.
+        # ``[{"OFFLINE": [...]}, {"REALTIME": [...]}]``. Merge into one mapping so
+        # the result is always an object keyed by table type.
+        if isinstance(data, list):
+            merged: dict[str, Any] = {}
+            for item in data:
+                if isinstance(item, dict):
+                    merged.update(item)
+            return merged
+        return data
+
+    OFFLINE: list[str] | None = Field(
+        default=None, description="OFFLINE segment names, when the table has them."
+    )
+    REALTIME: list[str] | None = Field(
+        default=None, description="REALTIME segment names, when the table has them."
+    )
+
+
+class SegmentIndexDetails(BaseModel):
+    """Per-column index metadata for a single segment."""
+
+    model_config = ConfigDict(extra="allow")
+
+    indexes: Any = Field(
+        default=None,
+        description="Per-column index metadata (index types present on each column).",
+    )
+    columns: Any = Field(
+        default=None, description="Per-column metadata for the segment, when present."
+    )
+
+
+class SegmentMetadata(BaseModel):
+    """Metadata for a table's segments (rows, sizes, time boundaries).
+
+    Pinot returns a mapping keyed by segment name whose values vary per segment,
+    so the contents are preserved as-is rather than enumerated here.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class PinotSchema(BaseModel):
+    """A Pinot table schema definition (column field specs)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    schemaName: str | None = Field(default=None, description="The schema name.")
+    dimensionFieldSpecs: list[dict[str, Any]] | None = Field(
+        default=None, description="Dimension (attribute) column specifications."
+    )
+    metricFieldSpecs: list[dict[str, Any]] | None = Field(
+        default=None, description="Metric (aggregatable measure) column specifications."
+    )
+    dateTimeFieldSpecs: list[dict[str, Any]] | None = Field(
+        default=None, description="Date/time column specifications."
+    )
+    primaryKeyColumns: list[str] | None = Field(
+        default=None, description="Primary key columns, for upsert-enabled tables."
+    )
+
+
+class TableConfig(BaseModel):
+    """A Pinot table configuration (``GET /tables/{name}``)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    tableName: str | None = Field(default=None, description="The table name.")
+    tableType: str | None = Field(
+        default=None, description="Table type: 'OFFLINE' or 'REALTIME'."
+    )
+    segmentsConfig: dict[str, Any] | None = Field(
+        default=None,
+        description="Retention, replication, and time-column settings.",
+    )
+    tableIndexConfig: dict[str, Any] | None = Field(
+        default=None, description="Index configuration (inverted, sorted, range, ...)."
+    )
+    tenants: dict[str, Any] | None = Field(
+        default=None, description="Broker and server tenant assignment."
+    )
+    ingestionConfig: dict[str, Any] | None = Field(
+        default=None, description="Ingestion / transform configuration, when present."
+    )
+
+
+class TableConfigSchema(BaseModel):
+    """Combined table configuration and schema (``GET /tableConfigs/{name}``).
+
+    The Pinot ``schema`` key is preserved as an extra field (rather than declared)
+    to avoid shadowing Pydantic's reserved ``schema`` attribute.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tableName: str | None = Field(default=None, description="The table name.")
+    offline: dict[str, Any] | None = Field(
+        default=None, description="OFFLINE table configuration, when present."
+    )
+    realtime: dict[str, Any] | None = Field(
+        default=None, description="REALTIME table configuration, when present."
+    )

--- a/mcp_pinot/server.py
+++ b/mcp_pinot/server.py
@@ -648,6 +648,52 @@ def pinot_query() -> str:
     return PROMPT_TEMPLATE.strip()
 
 
+@mcp.prompt
+def explore_table(table_name: str) -> str:
+    """Guide a structured exploration of a single Pinot table.
+
+    Args:
+        table_name: The Pinot table to explore (case-sensitive).
+    """
+    return (
+        f"Help me explore the Pinot table '{table_name}'.\n"
+        f"1. Call get_schema and get_table_config for '{table_name}' to learn its "
+        f"columns, types, and time column.\n"
+        f"2. Call table_details and segment_list for its size and segment layout.\n"
+        f"3. Run read_query with a small LIMIT (e.g. 10) to sample rows from "
+        f"'{table_name}'.\n"
+        f"4. Summarize the table's purpose, key dimensions/metrics, and time range."
+    )
+
+
+@mcp.resource("pinot://tables", mime_type="application/json")
+def tables_resource() -> str:
+    """The Pinot tables visible to this server (honors table filters)."""
+    tables = _call("tables_resource", _HINT_READ, pinot_client.get_tables)
+    return json.dumps({"tables": tables})
+
+
+@mcp.resource("pinot://schema/{schema_name}", mime_type="application/json")
+def schema_resource(schema_name: str) -> str:
+    """The Pinot schema definition for a given schema name."""
+    raw = _call(
+        "schema_resource", _HINT_READ, pinot_client.get_schema, schemaName=schema_name
+    )
+    return json.dumps(raw)
+
+
+@mcp.resource("pinot://table-config/{table_name}", mime_type="application/json")
+def table_config_resource(table_name: str) -> str:
+    """The Pinot table configuration for a given table name."""
+    raw = _call(
+        "table_config_resource",
+        _HINT_READ,
+        pinot_client.get_table_config,
+        tableName=table_name,
+    )
+    return json.dumps(raw)
+
+
 def main():
     """Main entry point for FastMCP Pinot Server"""
     tls_enabled = server_config.ssl_keyfile and server_config.ssl_certfile

--- a/mcp_pinot/server.py
+++ b/mcp_pinot/server.py
@@ -22,8 +22,15 @@ from mcp_pinot.models import (
     ConnectionDiagnostics,
     FilterReloadResult,
     OperationResult,
+    PinotSchema,
     QueryResult,
+    SegmentIndexDetails,
+    SegmentList,
+    SegmentMetadata,
+    TableConfig,
+    TableConfigSchema,
     TableList,
+    TableSizeDetails,
 )
 from mcp_pinot.pinot_client import PinotClient
 from mcp_pinot.prompts import PROMPT_TEMPLATE
@@ -124,6 +131,18 @@ def _preview_name(json_str: str, key: str) -> str:
     if not name:
         raise ToolError(f"Missing required field '{key}' in the JSON payload.")
     return str(name)
+
+
+def _as_json_str(payload: dict[str, Any] | str) -> str:
+    """Normalize a JSON-object-or-string write payload to a JSON string.
+
+    Tools accept either a structured object (preferred — clients get a real input
+    schema) or a raw JSON string (back-compat). Downstream client methods and the
+    Pinot REST API expect a JSON string, so objects are serialized here.
+    """
+    if isinstance(payload, dict):
+        return json.dumps(payload)
+    return payload
 
 
 @mcp.tool(
@@ -282,11 +301,12 @@ def table_details(
             min_length=1,
         ),
     ],
-) -> dict[str, Any]:
+) -> TableSizeDetails:
     """Get storage size details (reported and estimated bytes) for a table."""
-    return _call(
+    raw = _call(
         "table_details", _HINT_READ, pinot_client.get_table_detail, tableName=tableName
     )
+    return TableSizeDetails.model_validate(raw)
 
 
 @mcp.tool(
@@ -302,11 +322,12 @@ def segment_list(
         str,
         Field(description="Pinot table name (case-sensitive).", min_length=1),
     ],
-) -> dict[str, Any]:
+) -> SegmentList:
     """List the segments for a table, grouped by table type (OFFLINE/REALTIME)."""
-    return _call(
+    raw = _call(
         "segment_list", _HINT_READ, pinot_client.get_segments, tableName=tableName
     )
+    return SegmentList.model_validate(raw)
 
 
 @mcp.tool(
@@ -326,15 +347,16 @@ def index_column_details(
         str,
         Field(description="Segment name, as returned by segment_list.", min_length=1),
     ],
-) -> dict[str, Any]:
+) -> SegmentIndexDetails:
     """Get per-column index metadata for a specific segment."""
-    return _call(
+    raw = _call(
         "index_column_details",
         _HINT_READ,
         pinot_client.get_index_column_detail,
         tableName=tableName,
         segmentName=segmentName,
     )
+    return SegmentIndexDetails.model_validate(raw)
 
 
 @mcp.tool(
@@ -350,14 +372,15 @@ def segment_metadata_details(
         str,
         Field(description="Pinot table name (case-sensitive).", min_length=1),
     ],
-) -> dict[str, Any]:
+) -> SegmentMetadata:
     """Get metadata for all segments of a table (rows, sizes, time boundaries)."""
-    return _call(
+    raw = _call(
         "segment_metadata_details",
         _HINT_READ,
         pinot_client.get_segment_metadata_detail,
         tableName=tableName,
     )
+    return SegmentMetadata.model_validate(raw)
 
 
 @mcp.tool(
@@ -373,14 +396,15 @@ def tableconfig_schema_details(
         str,
         Field(description="Pinot table name (case-sensitive).", min_length=1),
     ],
-) -> dict[str, Any]:
+) -> TableConfigSchema:
     """Get the combined table configuration and schema for a table."""
-    return _call(
+    raw = _call(
         "tableconfig_schema_details",
         _HINT_READ,
         pinot_client.get_tableconfig_schema_detail,
         tableName=tableName,
     )
+    return TableConfigSchema.model_validate(raw)
 
 
 @mcp.tool(
@@ -394,11 +418,10 @@ def tableconfig_schema_details(
 )
 def create_schema(
     schemaJson: Annotated[
-        str,
+        dict[str, Any] | str,
         Field(
-            description="Pinot schema definition as a JSON string; must include "
-            "'schemaName'.",
-            min_length=2,
+            description="Pinot schema definition as a JSON object (preferred) or a "
+            "JSON string; must include 'schemaName'.",
         ),
     ],
     override: Annotated[
@@ -416,9 +439,11 @@ def create_schema(
 ) -> OperationResult:
     """Create a new Pinot schema.
 
-    Set ``dry_run=true`` to validate the payload and preview the effect without
+    Accepts the schema as a JSON object (preferred) or a JSON string. Set
+    ``dry_run=true`` to validate the payload and preview the effect without
     applying it.
     """
+    schemaJson = _as_json_str(schemaJson)
     if dry_run:
         name = _preview_name(schemaJson, "schemaName")
         return OperationResult(
@@ -452,8 +477,11 @@ def update_schema(
         Field(description="Name of the existing schema to update.", min_length=1),
     ],
     schemaJson: Annotated[
-        str,
-        Field(description="Updated schema definition as a JSON string.", min_length=2),
+        dict[str, Any] | str,
+        Field(
+            description="Updated schema definition as a JSON object (preferred) or a "
+            "JSON string.",
+        ),
     ],
     reload: Annotated[
         bool,
@@ -470,9 +498,11 @@ def update_schema(
 ) -> OperationResult:
     """Update an existing Pinot schema.
 
-    This can change column definitions on a live table; set ``dry_run=true`` to
-    preview without applying.
+    Accepts the schema as a JSON object (preferred) or a JSON string. This can
+    change column definitions on a live table; set ``dry_run=true`` to preview
+    without applying.
     """
+    schemaJson = _as_json_str(schemaJson)
     if dry_run:
         return OperationResult(
             status="dry_run",
@@ -504,11 +534,12 @@ def get_schema(
         str,
         Field(description="Schema name (case-sensitive).", min_length=1),
     ],
-) -> dict[str, Any]:
+) -> PinotSchema:
     """Fetch a Pinot schema definition by name."""
-    return _call(
+    raw = _call(
         "get_schema", _HINT_READ, pinot_client.get_schema, schemaName=schemaName
     )
+    return PinotSchema.model_validate(raw)
 
 
 @mcp.tool(
@@ -522,11 +553,10 @@ def get_schema(
 )
 def create_table_config(
     tableConfigJson: Annotated[
-        str,
+        dict[str, Any] | str,
         Field(
-            description="Pinot table configuration as a JSON string; must include "
-            "'tableName'.",
-            min_length=2,
+            description="Pinot table configuration as a JSON object (preferred) or a "
+            "JSON string; must include 'tableName'.",
         ),
     ],
     validationTypesToSkip: Annotated[
@@ -542,8 +572,10 @@ def create_table_config(
 ) -> OperationResult:
     """Create a new Pinot table configuration.
 
-    Set ``dry_run=true`` to validate the payload and preview without applying.
+    Accepts the config as a JSON object (preferred) or a JSON string. Set
+    ``dry_run=true`` to validate the payload and preview without applying.
     """
+    tableConfigJson = _as_json_str(tableConfigJson)
     if dry_run:
         name = _preview_name(tableConfigJson, "tableName")
         return OperationResult(
@@ -575,9 +607,10 @@ def update_table_config(
         Field(description="Name of the existing table to update.", min_length=1),
     ],
     tableConfigJson: Annotated[
-        str,
+        dict[str, Any] | str,
         Field(
-            description="Updated table configuration as a JSON string.", min_length=2
+            description="Updated table configuration as a JSON object (preferred) or "
+            "a JSON string.",
         ),
     ],
     validationTypesToSkip: Annotated[
@@ -593,9 +626,11 @@ def update_table_config(
 ) -> OperationResult:
     """Update an existing Pinot table configuration.
 
-    This changes the configuration of a live table; set ``dry_run=true`` to
-    preview without applying.
+    Accepts the config as a JSON object (preferred) or a JSON string. This changes
+    the configuration of a live table; set ``dry_run=true`` to preview without
+    applying.
     """
+    tableConfigJson = _as_json_str(tableConfigJson)
     if dry_run:
         return OperationResult(
             status="dry_run",
@@ -631,15 +666,16 @@ def get_table_config(
             description="Restrict to one table type; omit to return both when present."
         ),
     ] = None,
-) -> dict[str, Any]:
+) -> TableConfig:
     """Get the configuration for a table, optionally restricted to a table type."""
-    return _call(
+    raw = _call(
         "get_table_config",
         _HINT_READ,
         pinot_client.get_table_config,
         tableName=tableName,
         tableType=tableType,
     )
+    return TableConfig.model_validate(raw)
 
 
 @mcp.prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-pinot-server"
-version = "0.2.0"
+version = "3.2.0"
 description = "A production-grade MCP server for Apache Pinot"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -129,6 +129,42 @@ class TestFastMCPServer:
         )
 
     @pytest.mark.asyncio
+    async def test_explore_table_prompt_renders(self):
+        """The explore_table prompt renders with the provided table name."""
+        async with Client(mcp) as client:
+            result = await client.get_prompt("explore_table", {"table_name": "orders"})
+        text = " ".join(
+            m.content.text for m in result.messages if hasattr(m.content, "text")
+        )
+        assert "orders" in text
+
+    @pytest.mark.asyncio
+    async def test_resources_registered(self, mock_pinot_client):
+        """Catalog resources are registered (static + templated)."""
+        async with Client(mcp) as client:
+            resources = await client.list_resources()
+            templates = await client.list_resource_templates()
+        static_uris = {str(r.uri) for r in resources}
+        template_uris = {t.uriTemplate for t in templates}
+        assert "pinot://tables" in static_uris
+        assert any("pinot://schema/" in u for u in template_uris)
+        assert any("pinot://table-config/" in u for u in template_uris)
+
+    @pytest.mark.asyncio
+    async def test_read_tables_and_schema_resources(self, mock_pinot_client):
+        """The static and templated resources read through to the client."""
+        async with Client(mcp) as client:
+            tables = await client.read_resource("pinot://tables")
+            schema = await client.read_resource("pinot://schema/test_table")
+            config = await client.read_resource("pinot://table-config/test_table")
+        tables_text = " ".join(c.text for c in tables if hasattr(c, "text"))
+        schema_text = " ".join(c.text for c in schema if hasattr(c, "text"))
+        config_text = " ".join(c.text for c in config if hasattr(c, "text"))
+        assert "test_table" in tables_text
+        assert "schema" in schema_text
+        assert "config" in config_text
+
+    @pytest.mark.asyncio
     async def test_tool_test_connection(self, mock_pinot_client):
         """test_connection returns typed diagnostics."""
         async with Client(mcp) as client:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from fastmcp import Client
@@ -108,6 +109,54 @@ class TestFastMCPServer:
         assert props["limit"]["maximum"] == 10000
         assert props["limit"]["minimum"] == 1
         assert props["offset"]["minimum"] == 0
+
+    @pytest.mark.asyncio
+    async def test_inspection_tools_document_output_fields(self):
+        """Pass-through inspection tools publish documented output schemas."""
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+
+        def schema_text(name: str) -> str:
+            return json.dumps(tools[name].outputSchema)
+
+        assert "schemaName" in schema_text("get_schema")
+        assert "dimensionFieldSpecs" in schema_text("get_schema")
+        assert "reportedSizeInBytes" in schema_text("table_details")
+        assert "tableType" in schema_text("get_table_config")
+        assert "OFFLINE" in schema_text("segment_list")
+
+    @pytest.mark.asyncio
+    async def test_write_tools_accept_object_or_string_payload(self):
+        """schemaJson / tableConfigJson advertise object-or-string input."""
+        async with Client(mcp) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        schema_prop = tools["create_schema"].inputSchema["properties"]["schemaJson"]
+        config_prop = tools["create_table_config"].inputSchema["properties"][
+            "tableConfigJson"
+        ]
+        assert "anyOf" in schema_prop
+        assert "anyOf" in config_prop
+
+    @pytest.mark.asyncio
+    async def test_create_schema_accepts_structured_object(self, mock_pinot_client):
+        """A structured object payload is serialized to JSON for the client."""
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "create_schema",
+                {"schemaJson": {"schemaName": "obj_schema", "dimensionFieldSpecs": []}},
+            )
+        assert result.structured_content["status"] == "created"
+        called_arg = mock_pinot_client.create_schema.call_args.args[0]
+        assert isinstance(called_arg, str)
+        assert "obj_schema" in called_arg
+
+    def test_segment_list_normalizes_list_form(self):
+        """SegmentList merges Pinot's list-of-maps form into one object."""
+        from mcp_pinot.models import SegmentList
+
+        merged = SegmentList.model_validate([{"OFFLINE": ["s1"]}, {"REALTIME": ["s2"]}])
+        assert merged.OFFLINE == ["s1"]
+        assert merged.REALTIME == ["s2"]
 
     @pytest.mark.asyncio
     async def test_get_table_config_table_type_is_enum(self):


### PR DESCRIPTION
Consolidates the four arcade Trust Report improvement PRs into one. **Supersedes #105, #106, #107, #108** (closing those in favor of this).

The report (70/100, B) was **last assessed March 9 — before #100 merged**, so it doesn't yet reflect that work. These additive, non-breaking changes close the remaining gaps in all three rubric dimensions.

### Included
- **Version fix** — `pyproject` `0.2.0 → 3.2.0` (#100 had regressed it below the published 3.1.0, which would block release).
- **Definition Quality (50%)** — typed **output schemas** for the 7 inspection tools that returned bare `dict`; `schemaJson`/`tableConfigJson` accept a structured **object or string**. `extra=allow` preserves every field → response shapes unchanged.
- **Protocol Readiness (20%)** — `@mcp.resource` (`pinot://tables`, `schema/{}`, `table-config/{}`) + an `explore_table` prompt.
- **Supportability (30%)** — `SUPPORT.md`, GitHub issue templates, README badges.

### Tested (consolidated tree)
- Gate: ruff + format + mypy clean; **206 passed / 7 skipped**; coverage **90.5%** (gate 85%).
- Functional smoke (in-memory FastMCP client): all 15 tools expose `outputSchema` with documented fields; resources + templates resolve; both prompts render; a structured-dict `create_schema` dry-run works.

### Non-breaking
All additions; no existing tool name/shape/behavior changed; string payloads still work. Targets `v3.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)