### PR TITLE
feat(tools): paginate segment_list + clarify inspection tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   object **or** a JSON string (back-compatible).
 - MCP **resources** (`pinot://tables`, `pinot://schema/{name}`,
   `pinot://table-config/{name}`) and an `explore_table` prompt.
+- Pagination (`limit`/`offset` + `has_more`) for `segment_list`, and richer
+  descriptions on the inspection tools clarifying when to use each.
 - Repo supportability: `SUPPORT.md`, GitHub issue templates, and README status
   badges.
 

--- a/mcp_pinot/models.py
+++ b/mcp_pinot/models.py
@@ -156,10 +156,22 @@ class SegmentList(BaseModel):
         return data
 
     OFFLINE: list[str] | None = Field(
-        default=None, description="OFFLINE segment names, when the table has them."
+        default=None, description="OFFLINE segment names in this page, when present."
     )
     REALTIME: list[str] | None = Field(
-        default=None, description="REALTIME segment names, when the table has them."
+        default=None, description="REALTIME segment names in this page, when present."
+    )
+    total_segments: int | None = Field(
+        default=None, description="Total segments across all types before paging."
+    )
+    returned_segments: int | None = Field(
+        default=None, description="Number of segment names returned in this page."
+    )
+    offset: int | None = Field(
+        default=None, description="Zero-based offset of the first segment in this page."
+    )
+    has_more: bool | None = Field(
+        default=None, description="True when more segments remain beyond this page."
     )
 
 

--- a/mcp_pinot/server.py
+++ b/mcp_pinot/server.py
@@ -302,7 +302,14 @@ def table_details(
         ),
     ],
 ) -> TableSizeDetails:
-    """Get storage size details (reported and estimated bytes) for a table."""
+    """Get a table's storage footprint: reported vs. estimated size in bytes.
+
+    Use this for capacity/size questions about a whole table. It does NOT list
+    segments (use ``segment_list``) or return row counts/time boundaries (use
+    ``segment_metadata_details``). ``reportedSizeInBytes`` is what the servers
+    currently hosting the segments report; ``estimatedSizeInBytes`` assumes every
+    replica is present.
+    """
     raw = _call(
         "table_details", _HINT_READ, pinot_client.get_table_detail, tableName=tableName
     )
@@ -320,14 +327,53 @@ def table_details(
 def segment_list(
     tableName: Annotated[
         str,
-        Field(description="Pinot table name (case-sensitive).", min_length=1),
+        Field(
+            description="Pinot table name (case-sensitive), without the "
+            "_OFFLINE/_REALTIME suffix.",
+            min_length=1,
+        ),
     ],
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum segment names to return in this page.", ge=1, le=10000
+        ),
+    ] = 100,
+    offset: Annotated[
+        int,
+        Field(description="Zero-based offset for pagination.", ge=0),
+    ] = 0,
 ) -> SegmentList:
-    """List the segments for a table, grouped by table type (OFFLINE/REALTIME)."""
+    """List a table's segment names, grouped by table type (OFFLINE/REALTIME).
+
+    Use this to discover segment names — e.g. to get a ``segmentName`` for
+    ``index_column_details``, or to see how a table is partitioned. For per-segment
+    row counts / sizes / time boundaries call ``segment_metadata_details`` instead;
+    for the table's total storage size call ``table_details``.
+
+    Segment names are paginated (a busy table can have thousands) — use
+    ``limit``/``offset`` and the ``has_more`` flag to page through them.
+    """
     raw = _call(
         "segment_list", _HINT_READ, pinot_client.get_segments, tableName=tableName
     )
-    return SegmentList.model_validate(raw)
+    full = SegmentList.model_validate(raw)
+    flat = [("OFFLINE", s) for s in (full.OFFLINE or [])]
+    flat += [("REALTIME", s) for s in (full.REALTIME or [])]
+    total = len(flat)
+    page = flat[offset : offset + limit]
+    page_offline = [s for kind, s in page if kind == "OFFLINE"]
+    page_realtime = [s for kind, s in page if kind == "REALTIME"]
+    return full.model_copy(
+        update={
+            "OFFLINE": page_offline if full.OFFLINE is not None else None,
+            "REALTIME": page_realtime if full.REALTIME is not None else None,
+            "total_segments": total,
+            "returned_segments": len(page),
+            "offset": offset,
+            "has_more": offset + len(page) < total,
+        }
+    )
 
 
 @mcp.tool(
@@ -348,7 +394,13 @@ def index_column_details(
         Field(description="Segment name, as returned by segment_list.", min_length=1),
     ],
 ) -> SegmentIndexDetails:
-    """Get per-column index metadata for a specific segment."""
+    """Get per-column index metadata for ONE segment (which indexes each column has).
+
+    Use this to inspect how a specific segment is indexed (inverted, sorted, range,
+    etc.). Requires a ``segmentName`` from ``segment_list``. For a segment's row
+    count/size/time boundaries use ``segment_metadata_details``; for the table's
+    declared index *configuration* (not per-segment state) use ``get_table_config``.
+    """
     raw = _call(
         "index_column_details",
         _HINT_READ,
@@ -397,7 +449,13 @@ def tableconfig_schema_details(
         Field(description="Pinot table name (case-sensitive).", min_length=1),
     ],
 ) -> TableConfigSchema:
-    """Get the combined table configuration and schema for a table."""
+    """Get a table's configuration AND schema together, in one call.
+
+    A convenience that combines ``get_table_config`` (table settings: indexing,
+    retention, tenants) and ``get_schema`` (column definitions). Use it when you need
+    both at once; call the individual tools when you only need one. Returns the raw
+    Pinot ``/tableConfigs`` payload.
+    """
     raw = _call(
         "tableconfig_schema_details",
         _HINT_READ,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -373,6 +373,24 @@ class TestFastMCPServer:
         assert "OFFLINE" in result.structured_content
 
     @pytest.mark.asyncio
+    async def test_segment_list_paginates(self, mock_pinot_client):
+        """segment_list caps output and reports pagination metadata."""
+        mock_pinot_client.get_segments.return_value = {
+            "OFFLINE": [f"seg{i}" for i in range(5)],
+            "REALTIME": [f"rt{i}" for i in range(5)],
+        }
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "segment_list", {"tableName": "t", "limit": 3}
+            )
+        sc = result.structured_content
+        assert sc["total_segments"] == 10
+        assert sc["returned_segments"] == 3
+        assert sc["has_more"] is True
+        assert sc["OFFLINE"] == ["seg0", "seg1", "seg2"]
+        assert sc["REALTIME"] == []
+
+    @pytest.mark.asyncio
     async def test_tool_index_column_details(self, mock_pinot_client):
         async with Client(mcp) as client:
             result = await client.call_tool(

--- a/uv.lock
+++ b/uv.lock
@@ -777,7 +777,7 @@ cli = [
 
 [[package]]
 name = "mcp-pinot-server"
-version = "0.2.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Follow-up to #110 (which merged) — closes the **two remaining arcade Trust Report deductions** that #110 didn't cover.

### Supportability — pagination
The report flags *"No pagination support"* on **both `list_tables` and `segment_list`**; #100 paginated `list_tables` but `segment_list` still returned everything (risk: thousands of segments blow the context window). This adds `limit`/`offset` + `has_more` + `total_segments`/`returned_segments` to `segment_list`, paging across the combined OFFLINE/REALTIME set while keeping the grouped shape.

### Definition Quality — generic descriptions
The report calls the descriptions on the lowest-scoring tools *"extremely generic"* (`table_details` 63, `tableconfig_schema_details` 63, `index_column_details` 65, `segment_list`). Richer docstrings now explain **when to use each tool and how it differs** from its siblings (e.g. `segment_list` vs `segment_metadata_details` vs `table_details`).

Also commits the `uv.lock` version bump (`0.2.0 → 3.2.0`) that belonged with the version fix.

### Non-breaking
Additive — `limit`/`offset` default to a 100-row page (same pattern as `list_tables`); existing `segment_list` callers still get `OFFLINE`/`REALTIME`. Gate green locally: ruff + format + mypy clean, **207 passed / 7 skipped**, coverage **90.6%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)