### PR TITLE
chore(registry): sync server.json to 3.2.0 + add Smithery / privacy manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,8 +267,8 @@ jobs:
         metadata = json.loads(path.read_text())
         metadata["version"] = server_version
         for package in metadata.get("packages", []):
-            if package.get("registryType") == "pypi":
-                package["version"] = package_version
+            # All published packages (pypi, oci, ...) share the release version.
+            package["version"] = package_version
         path.write_text(json.dumps(metadata, indent=2) + "\n")
         with open(os.environ["GITHUB_OUTPUT"], "a") as output:
             print(f"server_version={server_version}", file=output)

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,50 @@
+# Privacy Policy
+
+> **Draft.** Required for listing in Anthropic's Claude Connectors Directory (a
+> missing/incomplete privacy policy is an automatic rejection). Review with your
+> legal/security team and host the final version at a stable HTTPS URL before
+> submitting.
+
+_Last updated: 2026-06-26_
+
+The Apache Pinot MCP Server (`mcp-pinot-server`, "the Server") is open-source
+software that an operator self-hosts to let an MCP client (e.g. Claude) query and
+inspect an Apache Pinot cluster the operator controls.
+
+## What the Server accesses
+
+- **Pinot cluster data and metadata** — table data, schemas, segments, and table
+  configurations from the Pinot cluster the operator configures it to connect to,
+  in order to answer the MCP client's tool/resource calls.
+- **Connection configuration** — endpoints and credentials (e.g. `PINOT_TOKEN`)
+  supplied by the operator through environment variables.
+
+## What the Server does *not* do
+
+- It does **not** collect, store, or transmit your data to the project maintainers
+  or any third party. The Server runs entirely within the operator's environment.
+- It does **not** persist query results or cluster data beyond the lifetime of a
+  request; it holds no database of its own.
+- It does **not** send analytics or telemetry.
+
+## Data handling
+
+- Requests flow only between the MCP client, the Server, and the operator's Pinot
+  cluster. Network egress is limited to the configured Pinot endpoints (and, when
+  an auth provider is enabled, the configured identity/authorization service).
+- Credentials are read from environment variables and used only to authenticate to
+  Pinot; they are not logged. See [SECURITY.md](SECURITY.md) for the security model
+  and production-exposure checklist.
+- Read-only query enforcement and optional table filtering limit what the Server
+  can access; write tools require explicit invocation and support `dry_run`.
+
+## Data retention
+
+The Server retains no data after a request completes. Any retention of Pinot data
+is governed by the operator's own Pinot deployment and policies.
+
+## Contact
+
+Report privacy or security concerns via the process in
+[SECURITY.md](SECURITY.md). For general questions, open a
+[GitHub issue](https://github.com/startreedata/mcp-pinot/issues).

--- a/REGISTRY_LISTING.md
+++ b/REGISTRY_LISTING.md
@@ -1,0 +1,75 @@
+# Registry & Marketplace Listing
+
+How `mcp-pinot` is (or can be) listed across MCP registries, and what's automated
+vs. manual. Run the manual steps **after** a release publishes the matching version
+to PyPI.
+
+## 1. Official MCP Registry — ✅ automated on release
+
+The `publish-mcp-registry` job in [`.github/workflows/release.yml`](.github/workflows/release.yml)
+already publishes [`server.json`](server.json) on every `v*` tag:
+
+- sets the version on all packages from the tag,
+- waits for the PyPI package to be visible,
+- authenticates with `mcp-publisher login github-oidc` (GitHub OIDC — the
+  `io.github.startreedata/*` namespace is authorized by the repo owner, so **no
+  manual login is needed**),
+- runs `mcp-publisher publish`.
+
+Ownership is verified because the `mcp-name: io.github.startreedata/mcp-pinot`
+marker in [README](README.md) ships in the PyPI long-description.
+
+**Verify after release:**
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.startreedata/mcp-pinot"
+```
+
+> `server.json` now also declares the OCI (Docker) package `ghcr.io/startreedata/mcp-pinot`.
+
+## 2. Glama — ✅ auto-indexed
+
+Glama crawls open-source MCP servers from GitHub; the README already shows its
+badge. Optionally claim the listing at <https://glama.ai> to manage metadata.
+
+## 3. Smithery — manual
+
+[`smithery.yaml`](smithery.yaml) is included (runs the PyPI package via `uvx` over
+stdio). Validate against the current [Smithery docs](https://smithery.ai/docs),
+then connect the repo / publish at <https://smithery.ai>. Smithery may prefer the
+Docker image — `ghcr.io/startreedata/mcp-pinot` is available.
+
+## 4. PulseMCP — manual (also auto-crawls)
+
+Use the **Submit** button at <https://www.pulsemcp.com>. It also indexes from
+GitHub + the official registry, so listing in #1 helps here.
+
+## 5. mcp.so — manual
+
+Submit via the form at <https://mcp.so>.
+
+## 6. Docker MCP Catalog — manual PR
+
+Open a PR at <https://github.com/docker/mcp-registry> (you ship a Docker image).
+Prefer the **Docker-built** tier for signed images + SBOM + provenance.
+
+## 7. awesome-mcp-servers — manual PR
+
+Add an entry via PR to <https://github.com/punkpeye/awesome-mcp-servers> (and any
+other curated lists) for SEO/discovery.
+
+## 8. Anthropic Claude Connectors Directory — manual, highest reach
+
+In-product across Claude. Requirements:
+
+- **Remote, internet-hosted** server (HTTPS) using **OAuth 2.0** — supported via
+  `AUTH_PROVIDER` + HTTP transport.
+- Every tool annotated with `title` + `readOnlyHint`/`destructiveHint` — ✅ done.
+- A **Privacy Policy** at a stable HTTPS URL — see [PRIVACY.md](PRIVACY.md) (draft;
+  needs legal review + hosting).
+- Submit from **Claude.ai → admin settings** (needs a **Team/Enterprise** org).
+
+## Visibility multipliers
+
+- Add GitHub repo **topics**: `mcp`, `model-context-protocol`, `apache-pinot`, `llm`.
+- Keep README badges + examples current (directories favor production-quality docs).
+- Announce the release (blog/social) and link the official-registry entry.

--- a/server.json
+++ b/server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.startreedata/mcp-pinot",
   "title": "Apache Pinot MCP Server",
-  "description": "Explore and query Apache Pinot clusters through MCP.",
+  "description": "Explore and query Apache Pinot clusters through MCP: read-only SQL plus schema, segment, and table-config inspection, with catalog resources and prompts.",
   "repository": {
     "url": "https://github.com/startreedata/mcp-pinot",
     "source": "github"
   },
   "websiteUrl": "https://startreedata.github.io/mcp-pinot/",
-  "version": "0.1.0",
+  "version": "3.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-pinot-server",
-      "version": "0.1.0",
+      "version": "3.2.0",
       "transport": {
         "type": "stdio"
       },
@@ -53,8 +53,28 @@
           "description": "Whether to enable Pinot multi-stage query engine support.",
           "format": "boolean",
           "default": "true"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode: 'stdio' (default, for desktop clients) or 'http'.",
+          "format": "string",
+          "default": "stdio"
+        },
+        {
+          "name": "AUTH_PROVIDER",
+          "description": "Inbound auth provider for HTTP transport (e.g. 'oauth'); required to bind a non-loopback host.",
+          "format": "string"
         }
       ]
+    },
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "ghcr.io/startreedata/mcp-pinot",
+      "version": "3.2.0",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,38 @@
+# Smithery configuration for the Apache Pinot MCP server.
+# Docs: https://smithery.ai/docs  — validate against the current schema before publishing.
+#
+# This runs the published PyPI package (mcp-pinot-server) over stdio via `uvx`,
+# so no pre-install or Docker image is required on the runner.
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - pinotControllerUrl
+      - pinotBrokerUrl
+    properties:
+      pinotControllerUrl:
+        type: string
+        title: Pinot Controller URL
+        description: HTTP(S) endpoint of the Pinot Controller.
+        default: http://localhost:9000
+      pinotBrokerUrl:
+        type: string
+        title: Pinot Broker URL
+        description: HTTP(S) endpoint of the Pinot Broker.
+        default: http://localhost:8000
+      pinotToken:
+        type: string
+        title: Pinot bearer token (optional)
+        description: Bearer/raw token used to authenticate to Pinot.
+  commandFunction: |-
+    (config) => ({
+      command: "uvx",
+      args: ["--from", "mcp-pinot-server", "mcp-pinot"],
+      env: {
+        MCP_TRANSPORT: "stdio",
+        PINOT_CONTROLLER_URL: config.pinotControllerUrl,
+        PINOT_BROKER_URL: config.pinotBrokerUrl,
+        ...(config.pinotToken ? { PINOT_TOKEN: config.pinotToken } : {})
+      }
+    })


### PR DESCRIPTION
Prep for listing `mcp-pinot` across MCP registries (queued behind the v3.2.0 release).

### Key fix — `server.json` was stale at `0.1.0`
The repo already publishes to the **official MCP Registry automatically** (`publish-mcp-registry` job in `release.yml`, via GitHub **OIDC** — no manual login needed). But `server.json` was pinned at `0.1.0`. This syncs it to **3.2.0**, adds the `MCP_TRANSPORT`/`AUTH_PROVIDER` env vars, and adds the **OCI/Docker package** (`ghcr.io/startreedata/mcp-pinot`).
- `release.yml`: the version-sync step now updates **all** packages (was `pypi`-only), so the new OCI entry stays in sync on future releases.

### New manifests for the non-automated registries
- **`smithery.yaml`** — Smithery listing (runs the PyPI package via `uvx` over stdio).
- **`PRIVACY.md`** — draft privacy policy required by the **Claude Connectors Directory** (needs legal review + HTTPS hosting).
- **`REGISTRY_LISTING.md`** — per-registry checklist: official registry (automated), Glama (auto), Smithery, PulseMCP, mcp.so, Docker MCP Catalog, awesome-mcp-servers, and the Claude Connectors Directory.

### Notes
- The official-registry publish runs on the `v3.2.0` tag; `release.yml` overrides `server.json`'s version from the tag at publish time, so the committed value is just kept accurate.
- Docs/manifests only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)