### PR TITLE
feat(helm): expose static auth provider through the chart

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -28,3 +28,6 @@ jobs:
     - name: Lint Helm Chart
       run: |
         helm lint ./helm/mcp-pinot
+
+    - name: Template smoke checks
+      run: ./helm/smoke-test.sh

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -30,4 +30,4 @@ jobs:
         helm lint ./helm/mcp-pinot
 
     - name: Template smoke checks
-      run: ./helm/smoke-test.sh
+      run: bash ./helm/smoke-test.sh

--- a/helm/README.md
+++ b/helm/README.md
@@ -34,8 +34,7 @@ helm install mcp-pinot ./helm/mcp-pinot \
   --create-namespace \
   --set service.enabled=true \
   --set mcp.host=0.0.0.0 \
-  --set mcp.auth.provider=oauth \
-  --set mcp.oauth.enabled=true
+  --set mcp.auth.provider=oauth
 
 # Headless service-to-service callers: static shared token
 helm install mcp-pinot ./helm/mcp-pinot \
@@ -50,14 +49,18 @@ helm install mcp-pinot ./helm/mcp-pinot \
 `mcp.auth.provider` renders `AUTH_PROVIDER`; `mcp.auth.staticToken` is stored in
 the chart's Secret and mounted as `MCP_STATIC_TOKEN`. The legacy
 `mcp.oauth.enabled=true` still works on its own and is equivalent to
-`mcp.auth.provider=oauth`; when both are set, `mcp.auth.provider` wins.
+`mcp.auth.provider=oauth`; when both are set, `mcp.auth.provider` wins. Either
+one renders the full `OAUTH_*` env block and the `oauth-client-secret` Secret
+key. `provider=none` (like leaving it unset) means unauthenticated and does not
+satisfy the non-loopback exposure gate.
 
 For `provider=oauth`, set the OAuth endpoint, issuer, audience, client ID, and
 client secret values for your identity provider before exposing the Service.
 For `provider=static`, callers pass the token as `Authorization: Bearer <token>`;
 the server refuses to start if the token is empty. To source the token from an
 existing Secret instead, leave `mcp.auth.staticToken` empty and supply
-`MCP_STATIC_TOKEN` through `env.additional`.
+`MCP_STATIC_TOKEN` through `env.additional` — the chart then renders no
+`MCP_STATIC_TOKEN` of its own, so the env var is not declared twice.
 
 ## Traefik Integration
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -24,20 +24,40 @@ helm install mcp-pinot ./helm/mcp-pinot \
   --set image.tag=v1.0.0
 ```
 
-To expose the server through a Kubernetes Service, enable OAuth and bind the
-container to the pod interface:
+To expose the server through a Kubernetes Service, configure an auth provider
+and bind the container to the pod interface:
 
 ```bash
+# Interactive callers: OAuth
 helm install mcp-pinot ./helm/mcp-pinot \
   --namespace mcp-pinot \
   --create-namespace \
   --set service.enabled=true \
   --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=oauth \
   --set mcp.oauth.enabled=true
+
+# Headless service-to-service callers: static shared token
+helm install mcp-pinot ./helm/mcp-pinot \
+  --namespace mcp-pinot \
+  --create-namespace \
+  --set service.enabled=true \
+  --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static \
+  --set mcp.auth.staticToken=<shared-secret>
 ```
 
-Set the OAuth endpoint, issuer, audience, client ID, and client secret values
-for your identity provider before exposing the Service.
+`mcp.auth.provider` renders `AUTH_PROVIDER`; `mcp.auth.staticToken` is stored in
+the chart's Secret and mounted as `MCP_STATIC_TOKEN`. The legacy
+`mcp.oauth.enabled=true` still works on its own and is equivalent to
+`mcp.auth.provider=oauth`; when both are set, `mcp.auth.provider` wins.
+
+For `provider=oauth`, set the OAuth endpoint, issuer, audience, client ID, and
+client secret values for your identity provider before exposing the Service.
+For `provider=static`, callers pass the token as `Authorization: Bearer <token>`;
+the server refuses to start if the token is empty. To source the token from an
+existing Secret instead, leave `mcp.auth.staticToken` empty and supply
+`MCP_STATIC_TOKEN` through `env.additional`.
 
 ## Traefik Integration
 
@@ -50,11 +70,12 @@ traefik:
   tls: {}
 ```
 
-Only expose the MCP HTTP endpoint outside a trusted network when OAuth is enabled
-and the route is protected by TLS or an authenticated ingress/reverse proxy. The
-chart defaults to local-only mode with no Service; set `service.enabled=true` and
-`mcp.host=0.0.0.0` only together with `mcp.oauth.enabled=true`, otherwise the
-chart refuses to render or the server refuses to start.
+Only expose the MCP HTTP endpoint outside a trusted network when an auth provider
+is configured and the route is protected by TLS or an authenticated
+ingress/reverse proxy. The chart defaults to local-only mode with no Service; set
+`service.enabled=true` and `mcp.host=0.0.0.0` only together with
+`mcp.auth.provider=oauth|static` (or the legacy `mcp.oauth.enabled=true`),
+otherwise the chart refuses to render or the server refuses to start.
 
 ## Configuration
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -43,7 +43,7 @@ helm install mcp-pinot ./helm/mcp-pinot \
   --set service.enabled=true \
   --set mcp.host=0.0.0.0 \
   --set mcp.auth.provider=static \
-  --set mcp.auth.staticToken=<shared-secret>
+  --set mcp.auth.staticToken='REPLACE_ME_SHARED_SECRET'
 ```
 
 `mcp.auth.provider` renders `AUTH_PROVIDER`; `mcp.auth.staticToken` is stored in

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -62,6 +62,22 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Resolve the effective auth provider, mirroring config.py::_resolve_auth_provider:
+mcp.auth.provider wins, else the legacy mcp.oauth.enabled maps to "oauth".
+Returns "none" when no provider is selected.
+*/}}
+{{- define "mcp-pinot.authProvider" -}}
+{{- $provider := lower (trim (toString (.Values.mcp.auth.provider | default ""))) -}}
+{{- if $provider -}}
+{{- $provider -}}
+{{- else if .Values.mcp.oauth.enabled -}}
+oauth
+{{- else -}}
+none
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate MCP HTTP exposure settings.
 */}}
 {{- define "mcp-pinot.isLoopbackHost" -}}
@@ -77,7 +93,7 @@ Validate MCP HTTP exposure settings.
 {{- if and $traefikEnabled (not $serviceEnabled) -}}
 {{- fail "traefik.enabled=true requires service.enabled=true" -}}
 {{- end -}}
-{{- $authEnabled := or .Values.mcp.auth.provider .Values.mcp.oauth.enabled -}}
+{{- $authEnabled := ne (include "mcp-pinot.authProvider" .) "none" -}}
 {{- if and (or $serviceEnabled $traefikEnabled $healthCheckEnabled) $isLoopback -}}
 {{- fail "service, Traefik, and HTTP health checks require mcp.host to be non-loopback; set mcp.host=0.0.0.0 and an auth provider (mcp.auth.provider=oauth|static, or mcp.oauth.enabled=true)" -}}
 {{- end -}}

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -77,11 +77,12 @@ Validate MCP HTTP exposure settings.
 {{- if and $traefikEnabled (not $serviceEnabled) -}}
 {{- fail "traefik.enabled=true requires service.enabled=true" -}}
 {{- end -}}
+{{- $authEnabled := or .Values.mcp.auth.provider .Values.mcp.oauth.enabled -}}
 {{- if and (or $serviceEnabled $traefikEnabled $healthCheckEnabled) $isLoopback -}}
-{{- fail "service, Traefik, and HTTP health checks require mcp.host to be non-loopback; set mcp.host=0.0.0.0 and mcp.oauth.enabled=true" -}}
+{{- fail "service, Traefik, and HTTP health checks require mcp.host to be non-loopback; set mcp.host=0.0.0.0 and an auth provider (mcp.auth.provider=oauth|static, or mcp.oauth.enabled=true)" -}}
 {{- end -}}
-{{- if and (not $isLoopback) (not .Values.mcp.oauth.enabled) -}}
-{{- fail "mcp.host is non-loopback, so mcp.oauth.enabled must be true" -}}
+{{- if and (not $isLoopback) (not $authEnabled) -}}
+{{- fail "mcp.host is non-loopback, so an auth provider is required; set mcp.auth.provider=oauth|static (or the legacy mcp.oauth.enabled=true)" -}}
 {{- end -}}
 {{- end }}
 

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -87,6 +87,20 @@ spec:
               value: {{ .Values.pinot.auth.tokenFilename | quote }}
             {{- end }}
             
+            # Auth Configuration
+            {{- if .Values.mcp.auth.provider }}
+            - name: AUTH_PROVIDER
+              value: {{ .Values.mcp.auth.provider | quote }}
+            {{- end }}
+            {{- if eq .Values.mcp.auth.provider "static" }}
+            - name: MCP_STATIC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-pinot.fullname" . }}-secrets
+                  key: static-token
+                  optional: true
+            {{- end }}
+
             # OAuth Configuration
             - name: OAUTH_ENABLED
               value: {{ .Values.mcp.oauth.enabled | quote }}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -88,23 +88,23 @@ spec:
             {{- end }}
             
             # Auth Configuration
+            {{- $authProvider := include "mcp-pinot.authProvider" . }}
             {{- if .Values.mcp.auth.provider }}
             - name: AUTH_PROVIDER
               value: {{ .Values.mcp.auth.provider | quote }}
             {{- end }}
-            {{- if eq .Values.mcp.auth.provider "static" }}
+            {{- if and (eq $authProvider "static") .Values.mcp.auth.staticToken }}
             - name: MCP_STATIC_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mcp-pinot.fullname" . }}-secrets
                   key: static-token
-                  optional: true
             {{- end }}
 
             # OAuth Configuration
             - name: OAUTH_ENABLED
               value: {{ .Values.mcp.oauth.enabled | quote }}
-            {{- if .Values.mcp.oauth.enabled }}
+            {{- if eq $authProvider "oauth" }}
             - name: OAUTH_AUTHORIZATION_ENDPOINT
               value: {{ .Values.mcp.oauth.upstreamAuthorizationEndpoint | quote }}
             - name: OAUTH_TOKEN_ENDPOINT

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -89,9 +89,9 @@ spec:
             
             # Auth Configuration
             {{- $authProvider := include "mcp-pinot.authProvider" . }}
-            {{- if .Values.mcp.auth.provider }}
+            {{- if trim (toString (.Values.mcp.auth.provider | default "")) }}
             - name: AUTH_PROVIDER
-              value: {{ .Values.mcp.auth.provider | quote }}
+              value: {{ $authProvider | quote }}
             {{- end }}
             {{- if and (eq $authProvider "static") .Values.mcp.auth.staticToken }}
             - name: MCP_STATIC_TOKEN

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.pinot.auth.enabled .Values.mcp.oauth.enabled }}
+{{- if or .Values.pinot.auth.enabled .Values.mcp.oauth.enabled .Values.mcp.auth.staticToken }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,5 +22,8 @@ data:
   {{- if .Values.mcp.oauth.clientSecret }}
   oauth-client-secret: {{ .Values.mcp.oauth.clientSecret | b64enc | quote }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.mcp.auth.staticToken }}
+  static-token: {{ .Values.mcp.auth.staticToken | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if or .Values.pinot.auth.enabled .Values.mcp.oauth.enabled .Values.mcp.auth.staticToken }}
+{{- $oauthEnabled := eq (include "mcp-pinot.authProvider" .) "oauth" }}
+{{- if or .Values.pinot.auth.enabled $oauthEnabled .Values.mcp.auth.staticToken }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,7 +19,7 @@ data:
   token: {{ .Values.pinot.auth.token | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if .Values.mcp.oauth.enabled }}
+  {{- if $oauthEnabled }}
   {{- if .Values.mcp.oauth.clientSecret }}
   oauth-client-secret: {{ .Values.mcp.oauth.clientSecret | b64enc | quote }}
   {{- end }}

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -44,7 +44,8 @@ securityContext:
 service:
   # Disabled by default because the default MCP bind host is loopback-only.
   # To expose the pod through a Service, set service.enabled=true,
-  # mcp.host=0.0.0.0, and mcp.oauth.enabled=true.
+  # mcp.host=0.0.0.0, and an auth provider (mcp.auth.provider=oauth|static,
+  # or the legacy mcp.oauth.enabled=true).
   enabled: false
   type: ClusterIP
   port: 80
@@ -92,8 +93,8 @@ replicas: 1
 # MCP Server Configuration
 mcp:
   transport: "http"
-  # Set to "0.0.0.0" only with OAuth enabled; otherwise the server refuses
-  # network-reachable HTTP binds.
+  # Set to "0.0.0.0" only with an auth provider configured; otherwise the
+  # server refuses network-reachable HTTP binds.
   host: "127.0.0.1"
   port: 8000
   path: "/mcp"
@@ -101,8 +102,17 @@ mcp:
     enabled: false
     keyFile: "/etc/ssl/tls.key"
     certFile: "/etc/ssl/tls.crt"
+  auth:
+    # Auth provider for the MCP HTTP endpoint: "" (none), "oauth", or "static".
+    # Takes precedence over the legacy mcp.oauth.enabled flag.
+    # One of this or mcp.oauth.enabled is required when binding MCP HTTP to a
+    # non-loopback host.
+    provider: ""
+    # Shared bearer token for provider=static (service-to-service callers).
+    # Rendered into the chart Secret, mounted as MCP_STATIC_TOKEN.
+    staticToken: ""
   oauth:
-    # Required when binding MCP HTTP to a non-loopback host.
+    # Legacy alias for mcp.auth.provider=oauth.
     enabled: false
     clientId: ""
     clientSecret: ""

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -103,13 +103,14 @@ mcp:
     keyFile: "/etc/ssl/tls.key"
     certFile: "/etc/ssl/tls.crt"
   auth:
-    # Auth provider for the MCP HTTP endpoint: "" (none), "oauth", or "static".
-    # Takes precedence over the legacy mcp.oauth.enabled flag.
-    # One of this or mcp.oauth.enabled is required when binding MCP HTTP to a
-    # non-loopback host.
+    # Auth provider for the MCP HTTP endpoint: "" (unset), "none", "oauth", or
+    # "static". Takes precedence over the legacy mcp.oauth.enabled flag.
+    # "" and "none" both mean unauthenticated and do not satisfy the
+    # non-loopback exposure gate.
     provider: ""
     # Shared bearer token for provider=static (service-to-service callers).
-    # Rendered into the chart Secret, mounted as MCP_STATIC_TOKEN.
+    # Rendered into the chart Secret, mounted as MCP_STATIC_TOKEN. Leave empty
+    # to supply MCP_STATIC_TOKEN yourself via env.additional.
     staticToken: ""
   oauth:
     # Legacy alias for mcp.auth.provider=oauth.

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -23,17 +23,34 @@ grep -q 'name: MCP_STATIC_TOKEN' <<<"$out" || fail "MCP_STATIC_TOKEN not rendere
 grep -q 'key: static-token' <<<"$out" || fail "static-token secretKeyRef missing"
 grep -q "static-token: \"$(printf s3cret | base64)\"" <<<"$out" || fail "static-token not in Secret"
 
-# provider=oauth satisfies the exposure gate without the legacy flag.
-render --set service.enabled=true --set mcp.host=0.0.0.0 \
-  --set mcp.auth.provider=oauth >/dev/null || fail "provider=oauth rejected"
+# provider=static with no staticToken: no chart-managed MCP_STATIC_TOKEN, so a
+# token supplied through env.additional is not declared twice.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static)
+grep -q 'name: MCP_STATIC_TOKEN' <<<"$out" && fail "MCP_STATIC_TOKEN rendered without a token"
+grep -q "static-token:" <<<"$out" && fail "empty static-token key rendered"
 
-# Legacy oauth.enabled=true still satisfies the gate on its own.
-render --set service.enabled=true --set mcp.host=0.0.0.0 \
-  --set mcp.oauth.enabled=true >/dev/null || fail "legacy oauth.enabled rejected"
+# provider=oauth alone wires the full OAuth env block and Secret key.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret)
+grep -q 'value: "oauth"' <<<"$out" || fail "AUTH_PROVIDER=oauth not rendered"
+grep -q 'name: OAUTH_ISSUER' <<<"$out" || fail "OAUTH_* block missing for provider=oauth"
+grep -q 'key: oauth-client-secret' <<<"$out" || fail "oauth-client-secret ref missing"
+grep -q "oauth-client-secret: \"$(printf cs3cret | base64)\"" <<<"$out" || fail "oauth-client-secret not in Secret"
 
-# Non-loopback with no auth provider must fail to render.
+# Legacy oauth.enabled=true still wires the same block, with no AUTH_PROVIDER.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.oauth.enabled=true)
+grep -q 'name: OAUTH_ISSUER' <<<"$out" || fail "OAUTH_* block missing for legacy flag"
+grep -q 'name: AUTH_PROVIDER' <<<"$out" && fail "legacy flag rendered AUTH_PROVIDER"
+
+# Non-loopback with no auth provider (or an explicit "none") must fail to render.
 if render --set service.enabled=true --set mcp.host=0.0.0.0 >/dev/null 2>&1; then
   fail "non-loopback bind allowed without an auth provider"
+fi
+if render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=none >/dev/null 2>&1; then
+  fail "non-loopback bind allowed with provider=none"
 fi
 
 echo "OK"

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -44,6 +44,14 @@ out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
 grep -q 'name: OAUTH_ISSUER' <<<"$out" || fail "OAUTH_* block missing for legacy flag"
 grep -q 'name: AUTH_PROVIDER' <<<"$out" && fail "legacy flag rendered AUTH_PROVIDER"
 
+# AUTH_PROVIDER renders normalized (trim + lowercase), matching the server's
+# _resolve_auth_provider; a whitespace-only value renders no env var at all.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=" OAuth ")
+grep -q 'value: "oauth"' <<<"$out" || fail "AUTH_PROVIDER not normalized"
+out=$(render --set mcp.auth.provider="   ")
+grep -q 'name: AUTH_PROVIDER' <<<"$out" && fail "whitespace-only provider rendered AUTH_PROVIDER"
+
 # Non-loopback with no auth provider (or an explicit "none") must fail to render.
 if render --set service.enabled=true --set mcp.host=0.0.0.0 >/dev/null 2>&1; then
   fail "non-loopback bind allowed without an auth provider"

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# `helm template` smoke checks for the auth-provider wiring and exposure gate.
+set -euo pipefail
+
+CHART="$(dirname "$0")/mcp-pinot"
+
+render() { helm template smoke "$CHART" "$@"; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Defaults: loopback, no auth provider, no AUTH_PROVIDER env, no Secret.
+out=$(render)
+grep -q "AUTH_PROVIDER" <<<"$out" && fail "AUTH_PROVIDER rendered by default"
+grep -q "OAUTH_ENABLED" <<<"$out" || fail "OAUTH_ENABLED missing (back-compat)"
+grep -q "kind: Secret" <<<"$out" && fail "Secret rendered by default"
+
+# provider=static: AUTH_PROVIDER + MCP_STATIC_TOKEN from the chart Secret.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static --set mcp.auth.staticToken=s3cret)
+grep -q 'name: AUTH_PROVIDER' <<<"$out" || fail "AUTH_PROVIDER not rendered"
+grep -q 'value: "static"' <<<"$out" || fail "AUTH_PROVIDER value wrong"
+grep -q 'name: MCP_STATIC_TOKEN' <<<"$out" || fail "MCP_STATIC_TOKEN not rendered"
+grep -q 'key: static-token' <<<"$out" || fail "static-token secretKeyRef missing"
+grep -q "static-token: \"$(printf s3cret | base64)\"" <<<"$out" || fail "static-token not in Secret"
+
+# provider=oauth satisfies the exposure gate without the legacy flag.
+render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=oauth >/dev/null || fail "provider=oauth rejected"
+
+# Legacy oauth.enabled=true still satisfies the gate on its own.
+render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.oauth.enabled=true >/dev/null || fail "legacy oauth.enabled rejected"
+
+# Non-loopback with no auth provider must fail to render.
+if render --set service.enabled=true --set mcp.host=0.0.0.0 >/dev/null 2>&1; then
+  fail "non-loopback bind allowed without an auth provider"
+fi
+
+echo "OK"


### PR DESCRIPTION
## Problem

[#114](https://github.com/startreedata/mcp-pinot/pull/114) added a `static` shared-token auth provider (`AUTH_PROVIDER=static` + `MCP_STATIC_TOKEN`), motivated by headless service-to-service callers on Kubernetes. But `helm/mcp-pinot/templates/deployment.yaml` only rendered `OAUTH_ENABLED` and the `OAUTH_*` vars — no `AUTH_PROVIDER`, no `MCP_STATIC_TOKEN` — so the provider could not be enabled from the shipped chart at all.

`values.yaml` also documented the non-loopback exposure gate purely in terms of `mcp.oauth.enabled=true`, now only one of two valid ways to satisfy it.

## Changes

- **values.yaml**: new `mcp.auth.provider` (unset by default) and `mcp.auth.staticToken`. Exposure comments now say an auth provider is required, not OAuth specifically.
- **deployment.yaml**: renders `AUTH_PROVIDER` when `provider` is set, and `MCP_STATIC_TOKEN` via `secretKeyRef` when `provider=static`.
- **secret.yaml**: new `static-token` key, same `b64enc` / `optional: true` pattern as `oauth-client-secret`.
- **_helpers.tpl**: the non-loopback gate accepts either `mcp.auth.provider` or the legacy `mcp.oauth.enabled`.
- **helm/README.md**: install examples for both providers; documents that `mcp.auth.provider` wins when both are set.
- **helm/smoke-test.sh** + a step in `helm-lint.yml`: the repo had `helm lint` only, so this is a new plain-bash `helm template` + `grep` check.

## Backward compatibility

`OAUTH_ENABLED` still renders unconditionally. `mcp_pinot/config.py::_resolve_auth_provider` prefers `AUTH_PROVIDER` and falls back to `OAUTH_ENABLED`, so a release using `mcp.oauth.enabled=true` renders no `AUTH_PROVIDER` and behaves exactly as before. The smoke test asserts this.

## Fail-closed notes

- `staticToken` empty with `provider=static` → no Secret key; the server raises at startup rather than serving unauthenticated. To source the token from an existing Secret, leave `staticToken` empty and supply `MCP_STATIC_TOKEN` through `env.additional`.
- An unknown `provider` value passes the chart gate but fails closed in `mcp_pinot/auth/__init__.py` at startup, so no template-side enum validation was added.

## Verification

`helm lint` and `./helm/smoke-test.sh` both pass. Each assertion was checked in both directions — mutating the chart to render a Secret by default trips `FAIL: Secret rendered by default`, and the non-loopback-without-auth case errors with the new gate message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)