### PR TITLE
chore(release): bump version to 3.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-pinot-server"
-version = "3.2.0"
+version = "3.3.0"
 description = "A production-grade MCP server for Apache Pinot"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -777,7 +777,7 @@ cli = [
 
 [[package]]
 name = "mcp-pinot-server"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Release cut for the static shared-token auth provider (#114) + Helm exposure (#115) + arcade segment_list/registry follow-up (#113), all merged after v3.2.0 with no version bump. Bumps pyproject.toml + uv.lock 3.2.0 to 3.3.0 (uv lock --check passes). Tagging v3.3.0 after merge triggers the release (docker to ghcr, PyPI, GitHub release, MCP registry), then synced to StarTree Artifactory for cell installs. Needed because publish-pypi reads the version from pyproject — tagging without this bump would fail on a duplicate 3.2.0 PyPI publish.

Generated with Claude Code