### PR TITLE
helm: auto-generate the static shared token per env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Helm chart auto-generates the `static` shared token when
+  `mcp.auth.staticToken` is left empty (with `mcp.auth.provider=static`): the
+  chart mints a random 48-char token on first install and persists it in the
+  `-secrets` Secret, reusing it on every upgrade via `lookup`. Makes the static
+  provider zero-touch per environment — operators never pick or paste a token.
 - Built-in `static` auth provider for service-to-service callers: set
   `AUTH_PROVIDER=static` and `MCP_STATIC_TOKEN=<shared secret>`; a trusted backend
   presents it as `Authorization: Bearer <token>`. Satisfies the non-loopback-bind

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -78,6 +78,33 @@ none
 {{- end }}
 
 {{/*
+Resolve the static shared bearer token for provider=static.
+
+Precedence: an explicit mcp.auth.staticToken wins. Otherwise the token is
+auto-generated ONCE per env and persisted in this chart's Secret: on upgrades
+`lookup` finds the existing Secret and reuses its `static-token` key, so the
+value is stable across releases; only the very first install mints a fresh
+randAlphaNum. This makes provider=static zero-touch — no operator ever has to
+pick or paste a token. (During `helm template`/dry-run `lookup` returns empty,
+so a throwaway token is rendered; that output is never applied.)
+*/}}
+{{- define "mcp-pinot.staticToken" -}}
+{{- if .Values.mcp.auth.staticToken -}}
+{{- .Values.mcp.auth.staticToken -}}
+{{- else -}}
+{{- $secretName := printf "%s-secrets" (include "mcp-pinot.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $prior := "" -}}
+{{- if $existing -}}{{- $prior = index (default dict $existing.data) "static-token" -}}{{- end -}}
+{{- if $prior -}}
+{{- $prior | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate MCP HTTP exposure settings.
 */}}
 {{- define "mcp-pinot.isLoopbackHost" -}}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - name: AUTH_PROVIDER
               value: {{ $authProvider | quote }}
             {{- end }}
-            {{- if and (eq $authProvider "static") .Values.mcp.auth.staticToken }}
+            {{- if eq $authProvider "static" }}
             - name: MCP_STATIC_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- $oauthEnabled := eq (include "mcp-pinot.authProvider" .) "oauth" }}
-{{- if or .Values.pinot.auth.enabled $oauthEnabled .Values.mcp.auth.staticToken }}
+{{- $staticEnabled := eq (include "mcp-pinot.authProvider" .) "static" }}
+{{- if or .Values.pinot.auth.enabled $oauthEnabled $staticEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,7 +25,7 @@ data:
   oauth-client-secret: {{ .Values.mcp.oauth.clientSecret | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if .Values.mcp.auth.staticToken }}
-  static-token: {{ .Values.mcp.auth.staticToken | b64enc | quote }}
+  {{- if $staticEnabled }}
+  static-token: {{ include "mcp-pinot.staticToken" . | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -109,8 +109,11 @@ mcp:
     # non-loopback exposure gate.
     provider: ""
     # Shared bearer token for provider=static (service-to-service callers).
-    # Rendered into the chart Secret, mounted as MCP_STATIC_TOKEN. Leave empty
-    # to supply MCP_STATIC_TOKEN yourself via env.additional.
+    # Rendered into the chart Secret and mounted as MCP_STATIC_TOKEN.
+    # Leave EMPTY to auto-generate: with provider=static the chart mints a random
+    # token once on first install and persists it in the Secret (reused on every
+    # upgrade via lookup), so no operator ever picks or pastes one. Set explicitly
+    # only to pin a known value or share one supplied out-of-band.
     staticToken: ""
   oauth:
     # Legacy alias for mcp.auth.provider=oauth.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-pinot-server"
-version = "3.3.0"
+version = "3.4.0"
 description = "A production-grade MCP server for Apache Pinot"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What
Makes `mcp.auth.provider=static` **zero-touch**: when `mcp.auth.staticToken` is left empty, the chart mints a random 48-char token on first install and persists it in the `<release>-secrets` Secret, reusing it on every upgrade via `lookup`. `MCP_STATIC_TOKEN` is wired from that Secret whenever the provider is static.

## Why
The static provider previously required an operator to generate and paste a shared secret per environment — and paste the *same* value again on the consumer side (cosmiq). That doesn't scale. Now each env auto-gets a unique token with nothing to set.

## How consumers read it
The token lands in `<release>-secrets` under key `static-token`. A service-to-service caller (e.g. the cosmiq chart) references that Secret directly. Companion PRs: starforge-templates #1652 (mcp-server 0.4 → chart 3.4.0) and #1642 (cosmiq 0.5 mcp.auth wiring).

## Changes
- `_helpers.tpl`: new `mcp-pinot.staticToken` — explicit value wins, else `lookup`-or-`randAlphaNum 48` (stable across upgrades).
- `secret.yaml`: renders `static-token` whenever provider is static.
- `deployment.yaml`: `MCP_STATIC_TOKEN` set whenever provider is static.
- `values.yaml`: documents auto-generate.
- Bump to **3.4.0** (chart-only; image unchanged from 3.3.0).

## Release note
Needs tag `v3.4.0` → CI publishes to ghcr → **manual sync to Artifactory** (usual gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)