### PR TITLE
fix: canonicalize OCI metadata for MCP Registry releases

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,10 +1,6 @@
 name: Publish MCP Registry
 
 on:
-  # One-time recovery trigger for v4.0.0. This branch trigger is removed after
-  # the registry accepts the already-published release artifacts.
-  push:
-    branches: [codex/mcp-registry-v4-repair]
   workflow_dispatch:
     inputs:
       release-tag:
@@ -21,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release-tag || 'v4.0.0' }}
+      RELEASE_TAG: ${{ inputs.release-tag }}
 
     steps:
     - name: Checkout canonical metadata

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,64 @@
+name: Publish MCP Registry
+
+on:
+  # One-time recovery trigger for v4.0.0. This branch trigger is removed after
+  # the registry accepts the already-published release artifacts.
+  push:
+    branches: [codex/mcp-registry-v4-repair]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Existing release tag to publish, for example v4.0.0"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release-tag || 'v4.0.0' }}
+
+    steps:
+    - name: Checkout canonical metadata
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+      with:
+        python-version: '3.12'
+
+    - name: Verify release and prepare metadata
+      env:
+        PYPI_PACKAGE: mcp-pinot-server
+      run: |
+        case "$RELEASE_TAG" in
+          v*) ;;
+          *) echo "Release tag must start with v." >&2; exit 1 ;;
+        esac
+        git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG"
+        python -m pip install --upgrade pip
+        python -m pip install packaging
+        python scripts/prepare_registry_metadata.py "$RELEASE_TAG"
+        PACKAGE_VERSION="${RELEASE_TAG#v}"
+        curl --fail --silent --show-error \
+          "https://pypi.org/pypi/$PYPI_PACKAGE/$PACKAGE_VERSION/json" >/dev/null
+
+    - name: Install pinned MCP publisher
+      run: |
+        curl --fail --location --silent --show-error --retry 3 --retry-delay 5 --connect-timeout 30 --max-time 120 \
+          --output mcp-publisher.tar.gz \
+          "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz"
+        echo "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf  mcp-publisher.tar.gz" \
+          | sha256sum --check --strict
+        tar xzf mcp-publisher.tar.gz mcp-publisher
+        ./mcp-publisher validate
+
+    - name: Publish to MCP Registry
+      run: |
+        ./mcp-publisher login github-oidc
+        ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,33 +255,7 @@ jobs:
       env:
         RELEASE_TAG: ${{ github.ref_name }}
       run: |
-        python - <<'PY'
-        from pathlib import Path
-        import json
-        import os
-
-        from packaging.version import InvalidVersion, Version
-
-        raw_version = os.environ["RELEASE_TAG"]
-        server_version = raw_version[1:] if raw_version.startswith("v") else raw_version
-        try:
-            package_version = str(Version(server_version))
-        except InvalidVersion as exc:
-            raise SystemExit(f"Release tag {raw_version!r} is not a valid PyPI version: {exc}") from exc
-
-        path = Path("server.json")
-        metadata = json.loads(path.read_text())
-        metadata["version"] = server_version
-        for package in metadata.get("packages", []):
-            # All published packages (pypi, oci, ...) share the release version.
-            package["version"] = package_version
-        path.write_text(json.dumps(metadata, indent=2) + "\n")
-        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-            print(f"server_version={server_version}", file=output)
-            print(f"package_version={package_version}", file=output)
-        print(f"Set MCP Registry version to {server_version}")
-        print(f"Set PyPI package version to {package_version}")
-        PY
+        python scripts/prepare_registry_metadata.py "$RELEASE_TAG"
 
     - name: Wait for PyPI package metadata
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `OAUTH_GRANTED_SCOPES` (default `pinot:read pinot:write pinot:admin`): Pinot
+  authorization scopes granted to every principal the OAuth provider
+  authenticates, unioned onto the scopes the token already carries. General-purpose
+  OIDC providers issue a fixed scope catalog and cannot mint `pinot:*`, so before
+  this an authenticated user's token carried no Pinot scope and every tool call was
+  denied. Set to `pinot:read` for a read-only deployment.
+- Helm chart auto-generates the `static` shared token when `mcp.auth.staticToken`
+  is left empty (with `mcp.auth.provider=static`): a random token is minted on
+  first install and persisted in the `-secrets` Secret, reused on every upgrade via
+  `lookup`. Makes the static provider zero-touch per environment — operators never
+  pick, paste, or distribute a token.
+
+### Changed
+- `OAUTH_AUDIENCE` is now optional and defaults to the canonical MCP resource URI
+  (`OAUTH_BASE_URL` + `MCP_PATH`). A value that differs from that URI is honoured
+  with a warning instead of refusing to start, because providers that set `aud` to
+  the client ID cannot issue the resource URI.
+
 ### Fixed
 - Made confirmation tokens canonical and replay-safe by keying consumption on the
   signed nonce; malformed base64url, expiry, signature tampering, cross-operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   denied. Set to `pinot:read` for a read-only deployment.
 - Chart value `mcp.oauth.grantedScopes` renders `OAUTH_GRANTED_SCOPES`, so a
   read-only OIDC deployment is expressible from Helm (`[pinot:read]`).
+- Chart values `mcp.allowedHosts` / `mcp.allowedOrigins` render `MCP_ALLOWED_HOSTS`
+  / `MCP_ALLOWED_ORIGINS`, and the chart now fails render when `mcp.host` is a
+  wildcard bind with no Host allowlist. Without them a chart-managed deployment
+  bound to 0.0.0.0 exited at startup ("Refusing to start HTTP transport without an
+  exact Host allowlist") with no chart-level way to fix it; both variables were
+  also undocumented.
 - Helm chart auto-generates the `static` shared token when `mcp.auth.staticToken`
   is left empty (with `mcp.auth.provider=static`): a random token is minted on
   first install and persisted in the `-secrets` Secret, reused on every upgrade via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `AUTH_PROVIDER=oauth+static` (either spelling) accepts **both** an OIDC login and
+  the static shared token on one deployment, through a `ChainedTokenVerifier` behind
+  the OAuth provider. A hosted MCP normally has both kinds of caller — people with a
+  browser and one trusted backend without one — and selecting a single provider forced
+  a choice between them, with no clean workaround (a second deployment needs a second
+  hostname and certificate; many IdPs cannot issue the client-credentials grant).
+  The shared secret is checked first, so the backend never pays for a signing-key
+  fetch, and each credential keeps its own scopes: `MCP_STATIC_SCOPES` for the backend,
+  `OAUTH_GRANTED_SCOPES` for people. Chart: `mcp.auth.provider: oauth+static`.
 - `OAUTH_GRANTED_SCOPES` (default `pinot:read pinot:write pinot:admin`): Pinot
   authorization scopes granted to every principal the OAuth provider
   authenticates, unioned onto the scopes the token already carries. General-purpose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pick, paste, or distribute a token.
 
 ### Fixed
+- `test_connection` no longer reports a healthy deployment as broken. It probed
+  through the pinotdb DB-API connection, which no tool uses: against a broker whose
+  response pinotdb rejects (`check_sufficient_responded`) it returned
+  `connection_test`/`query_test`/`tables_test` all false while `read_query`,
+  `list_tables` and the inspection tools all worked. Each check now runs
+  independently through the same path as the tool it stands in for, the DB-API probe
+  is reported separately as informational `dbapi_test`, and the error names which
+  checks actually failed.
+- Health probes follow `mcp.ssl.enabled` instead of always using `http://`, so a
+  deployment that terminates TLS in the server can keep probes enabled — previously
+  the probe could never succeed there and had to be turned off, leaving Kubernetes
+  with no readiness signal.
 - Made confirmation tokens canonical and replay-safe by keying consumption on the
   signed nonce; malformed base64url, expiry, signature tampering, cross-operation
   reuse, and string-malleated replays are rejected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OIDC providers issue a fixed scope catalog and cannot mint `pinot:*`, so before
   this an authenticated user's token carried no Pinot scope and every tool call was
   denied. Set to `pinot:read` for a read-only deployment.
+- Chart value `mcp.oauth.grantedScopes` renders `OAUTH_GRANTED_SCOPES`, so a
+  read-only OIDC deployment is expressible from Helm (`[pinot:read]`).
 - Helm chart auto-generates the `static` shared token when `mcp.auth.staticToken`
   is left empty (with `mcp.auth.provider=static`): a random token is minted on
   first install and persisted in the `-secrets` Secret, reused on every upgrade via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `lookup`. Makes the static provider zero-touch per environment — operators never
   pick, paste, or distribute a token.
 
-### Changed
-- `OAUTH_AUDIENCE` is now optional and defaults to the canonical MCP resource URI
-  (`OAUTH_BASE_URL` + `MCP_PATH`). A value that differs from that URI is honoured
-  with a warning instead of refusing to start, because providers that set `aud` to
-  the client ID cannot issue the resource URI.
-
 ### Fixed
 - Made confirmation tokens canonical and replay-safe by keying consumption on the
   signed nonce; malformed base64url, expiry, signature tampering, cross-operation
@@ -44,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate-field detection.
 
 ### Changed
+- `OAUTH_AUDIENCE` is now optional and defaults to the canonical MCP resource URI
+  (`OAUTH_BASE_URL` + `MCP_PATH`). A value that differs from that URI is honoured
+  with a warning instead of refusing to start, because providers that set `aud` to
+  the client ID cannot issue the resource URI.
 - Helm intentionally supports one replica while confirmation and rate-limit state
   are process-local; rolling updates no longer overlap two server processes and the
   optional PDB defaults to `maxUnavailable: 1`.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ by a checked-out file.
 |---|---|---|
 | Claude Desktop | `MCP_TRANSPORT=stdio` | Default and recommended for local desktop use; no HTTP listener is started. |
 | Local HTTP | `MCP_TRANSPORT=http`, `MCP_HOST=127.0.0.1` | Explicit local web profile. Accessible only from the same machine. |
-| Remote HTTP/HTTPS | `MCP_TRANSPORT=http`, `MCP_HOST=0.0.0.0`, `AUTH_PROVIDER=oauth`\|`static` | The server refuses non-loopback HTTP/HTTPS binds unless an auth provider is active. Use TLS directly or an authenticated reverse proxy. |
+| Remote HTTP/HTTPS | `MCP_TRANSPORT=http`, `MCP_HOST=0.0.0.0`, `MCP_ALLOWED_HOSTS=<host[:port]>`, `AUTH_PROVIDER=oauth`\|`static`\|`oauth+static` | The server refuses non-loopback HTTP/HTTPS binds unless an auth provider is active, and a wildcard bind requires an explicit Host allowlist. Use `oauth+static` to serve interactive users and one trusted backend at once. Use TLS directly or an authenticated reverse proxy. |
 | Helm exposure | `service.enabled=true`, `mcp.host=0.0.0.0`, `mcp.oauth.enabled=true` | Helm defaults are local-only and render no Service unless exposure is explicitly enabled. |
 
 ### Pinot Connection
@@ -186,7 +186,8 @@ An auth provider is required before binding HTTP or HTTPS to a non-loopback host
 
 | Variable | Default | Description |
 |---|---|---|
-| `AUTH_PROVIDER` | unset | Active auth provider: `none` (default), `oauth`, or `static`. Some provider is required before a non-loopback bind. |
+| `AUTH_PROVIDER` | unset | Active auth provider: `none` (default), `oauth`, `static`, or `oauth+static`. Some provider is required before a non-loopback bind. |
+| | | `oauth+static` accepts both an OIDC login and the shared token on one deployment — the usual hosted case, where people use a browser and one trusted backend cannot. Either spelling works; the shared secret is checked first, and each credential keeps its own scopes (`MCP_STATIC_SCOPES` vs `OAUTH_GRANTED_SCOPES`). |
 | `MCP_STATIC_TOKEN` | empty | Shared bearer secret for `AUTH_PROVIDER=static` — a service-to-service caller sends it as `Authorization: Bearer <token>`. Required when the static provider is active. |
 | `MCP_STATIC_SCOPES` | `pinot:read pinot:write pinot:admin` | Space- or comma-separated scopes granted to the static principal. Use `pinot:read` for a read-only service. |
 | `OAUTH_ENABLED` | `false` | Legacy flag; `true` is equivalent to `AUTH_PROVIDER=oauth`. Enables OAuth authentication. |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ An auth provider is required before binding HTTP or HTTPS to a non-loopback host
 | `OAUTH_TOKEN_ENDPOINT` | empty | Upstream token endpoint. |
 | `OAUTH_JWKS_URI` | empty | JWKS URI used for token verification. |
 | `OAUTH_ISSUER` | empty | Expected token issuer. |
-| `OAUTH_AUDIENCE` | unset | Required with OAuth. Must equal the canonical MCP resource URI (`OAUTH_BASE_URL` without a trailing slash plus `MCP_PATH`). |
+| `OAUTH_AUDIENCE` | canonical MCP resource URI | Audience tokens are validated against. Defaults to `OAUTH_BASE_URL` (without a trailing slash) plus `MCP_PATH`, which is what RFC 9728 metadata advertises. Set it explicitly when the provider issues a different `aud` — many (Dex among them) set it to the client ID; the server logs a warning and honours your value. |
+| `OAUTH_GRANTED_SCOPES` | `pinot:read pinot:write pinot:admin` | Pinot scopes granted to every principal this provider authenticates, unioned onto the scopes the token already carries. Needed because general-purpose OIDC providers issue a fixed scope catalog and cannot mint `pinot:*`, so without a grant every tool call from a valid user would be denied. Set to `pinot:read` for a read-only deployment. |
 | `OAUTH_EXTRA_AUTH_PARAMS` | unset | Optional JSON object with additional authorization parameters. |
 
 ### Table Filtering
@@ -319,11 +320,13 @@ To enable OAuth authentication, set the following environment variables in your 
 - `OAUTH_JWKS_URI`: JSON Web Key Set URI for token verification
 - `OAUTH_ISSUER`: Token issuer identifier
 
-**Additional required variable:**
-- `OAUTH_AUDIENCE`: canonical MCP resource URI used for audience validation
-
 **Optional variables:**
+- `OAUTH_AUDIENCE`: audience tokens are validated against. Defaults to the canonical MCP resource URI (`OAUTH_BASE_URL` + `MCP_PATH`). Set it when your provider issues a different `aud` — for example an IdP that puts the client ID there.
+- `OAUTH_GRANTED_SCOPES`: Pinot scopes granted to authenticated principals (default all three). Use `pinot:read` to make the deployment read-only for every OIDC caller.
+- `OAUTH_REQUIRED_SCOPES`: baseline scopes an access token must already carry (default: none enforced).
 - `OAUTH_EXTRA_AUTH_PARAMS`: Additional authorization parameters as JSON object (e.g., `{"scope": "openid profile"}`)
+
+Tool-level authorization uses `pinot:read` / `pinot:write` / `pinot:admin`. General-purpose OIDC providers issue a fixed scope catalog and cannot mint resource scopes like these, so `OAUTH_GRANTED_SCOPES` is what makes an authenticated user able to call anything — narrow it rather than leaving tools ungated.
 
 Example configuration:
 ```bash

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ by a checked-out file.
 | `MCP_HOST` | `127.0.0.1` | HTTP bind host. Set `0.0.0.0` only with an auth provider enabled. |
 | `MCP_PORT` | `8080` | HTTP listen port. |
 | `MCP_PATH` | `/mcp` | MCP HTTP path. |
+| `MCP_ALLOWED_HOSTS` | exact host[:port] of a concrete bind | Comma-separated Host authorities accepted at the MCP endpoint. A wildcard bind (`0.0.0.0`, `::`) has no inferable public authority, so it defaults to empty and **the server exits at startup** until you list the names clients use, e.g. `mcp.example.com,mcp.example.com:443`. |
+| `MCP_ALLOWED_ORIGINS` | unset | Comma-separated browser `Origin` values accepted. Empty rejects requests that send `Origin` while still allowing clients that omit it. |
 | `MCP_SSL_KEYFILE` | unset | TLS private key path. Requires `MCP_SSL_CERTFILE`. |
 | `MCP_SSL_CERTFILE` | unset | TLS certificate path. Requires `MCP_SSL_KEYFILE`. |
 | `MCP_LOG_LEVEL` | `INFO` | Application log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Logs go to stderr so STDIO protocol output remains valid. |

--- a/helm/mcp-pinot/Chart.yaml
+++ b/helm/mcp-pinot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-pinot
 description: A production-grade MCP server for Apache Pinot
 type: application
-version: 4.0.0
-appVersion: "4.0.0"
+version: 4.1.0
+appVersion: "4.1.0"
 home: https://github.com/startreedata/mcp-pinot
 sources:
   - https://github.com/startreedata/mcp-pinot

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -130,6 +130,26 @@ the token from the Secret (key `static-token`), never from rendered manifests.
 {{- end }}
 
 {{/*
+Health-probe command. The server terminates TLS itself when mcp.ssl.enabled is set,
+so the probe has to speak the same scheme — an http:// probe against a TLS listener
+fails forever, which is why probes used to have to be disabled for any deployment
+serving HTTPS. The certificate is issued for the service's public names, never for
+127.0.0.1, so a loopback probe cannot verify it; verification is therefore skipped
+for the local check only. /livez and /readyz sit outside the MCP path, so the Host
+allowlist and the auth provider do not apply to them.
+
+Call as: include "mcp-pinot.probeCommand" (dict "root" . "check" .Values.healthCheck.liveness)
+*/}}
+{{- define "mcp-pinot.probeCommand" -}}
+{{- $scheme := ternary "https" "http" .root.Values.mcp.ssl.enabled -}}
+- python
+- -c
+- "import ssl, sys, urllib.request; ctx = ssl._create_unverified_context() if sys.argv[1].startswith('https') else None; sys.exit(0 if urllib.request.urlopen(sys.argv[1], timeout=float(sys.argv[2]), context=ctx).status == 200 else 1)"
+- {{ printf "%s://127.0.0.1:%v%s" $scheme .check.port .check.path | quote }}
+- {{ .check.timeoutSeconds | quote }}
+{{- end }}
+
+{{/*
 Validate MCP HTTP exposure settings.
 */}}
 {{- define "mcp-pinot.isLoopbackHost" -}}

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -78,15 +78,25 @@ none
 {{- end }}
 
 {{/*
-Whether the caller supplies MCP_STATIC_TOKEN themselves through env.additional.
+Whether env.additional already declares a given variable.
 
-When they do, the chart neither mints a token nor declares the variable, so the
-Pod keeps exactly one MCP_STATIC_TOKEN and no unused secret material is stored.
+Call as: include "mcp-pinot.envHas" (dict "root" . "name" "MCP_STATIC_TOKEN")
+Used so the chart never fights a caller who supplies a value itself: it neither
+mints a token nor declares a duplicate variable, and the exposure guards trust an
+externally supplied allowlist.
+*/}}
+{{- define "mcp-pinot.envHas" -}}
+{{- $name := .name -}}
+{{- range .root.Values.env.additional -}}
+{{- if eq (.name | default "") $name -}}true{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the caller supplies MCP_STATIC_TOKEN themselves through env.additional.
 */}}
 {{- define "mcp-pinot.staticTokenFromEnv" -}}
-{{- range .Values.env.additional -}}
-{{- if eq (.name | default "") "MCP_STATIC_TOKEN" -}}true{{- end -}}
-{{- end -}}
+{{- include "mcp-pinot.envHas" (dict "root" . "name" "MCP_STATIC_TOKEN") -}}
 {{- end }}
 
 {{/*
@@ -140,6 +150,10 @@ Validate MCP HTTP exposure settings.
 {{- end -}}
 {{- if and (not $isLoopback) (not $authEnabled) -}}
 {{- fail "mcp.host is non-loopback, so an auth provider is required; set mcp.auth.provider=oauth|static (or the legacy mcp.oauth.enabled=true)" -}}
+{{- end -}}
+{{- $hostAllowlisted := or .Values.mcp.allowedHosts (eq (include "mcp-pinot.envHas" (dict "root" . "name" "MCP_ALLOWED_HOSTS")) "true") -}}
+{{- if and (not $isLoopback) (not $hostAllowlisted) -}}
+{{- fail "mcp.host is a wildcard bind, which does not identify a public authority: set mcp.allowedHosts to the exact Host authorities clients use (e.g. [mcp.example.com, mcp.example.com:443]). Without it the server exits at startup instead of serving." -}}
 {{- end -}}
 {{- end }}
 

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -78,6 +78,19 @@ none
 {{- end }}
 
 {{/*
+Whether a given credential type is accepted, given that mcp.auth.provider may name
+several (e.g. "oauth+static" for interactive users plus one trusted backend).
+
+Call as: include "mcp-pinot.authHas" (dict "root" . "name" "static")
+*/}}
+{{- define "mcp-pinot.authHas" -}}
+{{- $want := .name -}}
+{{- range splitList "+" (include "mcp-pinot.authProvider" .root) -}}
+{{- if eq (trim .) $want -}}true{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Whether env.additional already declares a given variable.
 
 Call as: include "mcp-pinot.envHas" (dict "root" . "name" "MCP_STATIC_TOKEN")

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -78,6 +78,18 @@ none
 {{- end }}
 
 {{/*
+Whether the caller supplies MCP_STATIC_TOKEN themselves through env.additional.
+
+When they do, the chart neither mints a token nor declares the variable, so the
+Pod keeps exactly one MCP_STATIC_TOKEN and no unused secret material is stored.
+*/}}
+{{- define "mcp-pinot.staticTokenFromEnv" -}}
+{{- range .Values.env.additional -}}
+{{- if eq (.name | default "") "MCP_STATIC_TOKEN" -}}true{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve the static shared bearer token for provider=static.
 
 Precedence: an explicit mcp.auth.staticToken wins. Otherwise the token is

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -78,6 +78,36 @@ none
 {{- end }}
 
 {{/*
+Resolve the static shared bearer token for provider=static.
+
+Precedence: an explicit mcp.auth.staticToken wins. Otherwise the token is
+auto-generated ONCE per environment and persisted in this chart's Secret: on
+upgrades `lookup` finds the existing Secret and reuses its `static-token` key, so
+the value is stable across releases, and only the very first install mints a
+fresh randAlphaNum. This makes provider=static zero-touch — no operator ever has
+to pick, paste, or distribute a token, and each environment gets a distinct one.
+
+During `helm template`/`--dry-run` there is no cluster to look up, so a throwaway
+token is rendered; that output is never applied. Consumers must therefore read
+the token from the Secret (key `static-token`), never from rendered manifests.
+*/}}
+{{- define "mcp-pinot.staticToken" -}}
+{{- if .Values.mcp.auth.staticToken -}}
+{{- .Values.mcp.auth.staticToken -}}
+{{- else -}}
+{{- $secretName := printf "%s-secrets" (include "mcp-pinot.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $prior := "" -}}
+{{- if $existing -}}{{- $prior = index (default dict $existing.data) "static-token" -}}{{- end -}}
+{{- if $prior -}}
+{{- $prior | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate MCP HTTP exposure settings.
 */}}
 {{- define "mcp-pinot.isLoopbackHost" -}}

--- a/helm/mcp-pinot/templates/_helpers.tpl
+++ b/helm/mcp-pinot/templates/_helpers.tpl
@@ -100,9 +100,11 @@ externally supplied allowlist.
 */}}
 {{- define "mcp-pinot.envHas" -}}
 {{- $name := .name -}}
+{{- $found := false -}}
 {{- range .root.Values.env.additional -}}
-{{- if eq (.name | default "") $name -}}true{{- end -}}
+{{- if eq (.name | default "") $name -}}{{- $found = true -}}{{- end -}}
 {{- end -}}
+{{- if $found -}}true{{- end -}}
 {{- end }}
 
 {{/*
@@ -115,12 +117,14 @@ Whether the caller supplies MCP_STATIC_TOKEN themselves through env.additional.
 {{/*
 Resolve the static shared bearer token for provider=static.
 
-Precedence: an explicit mcp.auth.staticToken wins. Otherwise the token is
-auto-generated ONCE per environment and persisted in this chart's Secret: on
-upgrades `lookup` finds the existing Secret and reuses its `static-token` key, so
-the value is stable across releases, and only the very first install mints a
-fresh randAlphaNum. This makes provider=static zero-touch — no operator ever has
-to pick, paste, or distribute a token, and each environment gets a distinct one.
+This helper is used only when MCP_STATIC_TOKEN is not supplied through
+env.additional. In that chart-managed path, an explicit mcp.auth.staticToken wins.
+Otherwise the token is auto-generated ONCE per environment and persisted in this
+chart's Secret: on upgrades `lookup` finds the existing Secret and reuses its
+`static-token` key, so the value is stable across releases, and only the very first
+install mints a fresh randAlphaNum. This makes provider=static zero-touch — no
+operator ever has to pick, paste, or distribute a token, and each environment gets
+a distinct one.
 
 During `helm template`/`--dry-run` there is no cluster to look up, so a throwaway
 token is rendered; that output is never applied. Consumers must therefore read
@@ -171,6 +175,7 @@ Validate MCP HTTP exposure settings.
 {{- end }}
 
 {{- define "mcp-pinot.validateExposure" -}}
+{{- $host := lower (toString .Values.mcp.host) -}}
 {{- $isLoopback := eq (include "mcp-pinot.isLoopbackHost" .) "true" -}}
 {{- $serviceEnabled := .Values.service.enabled -}}
 {{- $traefikEnabled := .Values.traefik.enabled -}}
@@ -185,7 +190,8 @@ Validate MCP HTTP exposure settings.
 {{- fail "mcp.host is non-loopback, so an auth provider is required; set mcp.auth.provider=oauth|static (or the legacy mcp.oauth.enabled=true)" -}}
 {{- end -}}
 {{- $hostAllowlisted := or .Values.mcp.allowedHosts (eq (include "mcp-pinot.envHas" (dict "root" . "name" "MCP_ALLOWED_HOSTS")) "true") -}}
-{{- if and (not $isLoopback) (not $hostAllowlisted) -}}
+{{- $isWildcard := or (eq $host "0.0.0.0") (eq $host "::") (eq $host "[::]") -}}
+{{- if and $isWildcard (not $hostAllowlisted) -}}
 {{- fail "mcp.host is a wildcard bind, which does not identify a public authority: set mcp.allowedHosts to the exact Host authorities clients use (e.g. [mcp.example.com, mcp.example.com:443]). Without it the server exits at startup instead of serving." -}}
 {{- end -}}
 {{- end }}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -57,6 +57,14 @@ spec:
               value: {{ .Values.mcp.port | quote }}
             - name: MCP_PATH
               value: {{ .Values.mcp.path | quote }}
+            {{- if .Values.mcp.allowedHosts }}
+            - name: MCP_ALLOWED_HOSTS
+              value: {{ join "," .Values.mcp.allowedHosts | quote }}
+            {{- end }}
+            {{- if .Values.mcp.allowedOrigins }}
+            - name: MCP_ALLOWED_ORIGINS
+              value: {{ join "," .Values.mcp.allowedOrigins | quote }}
+            {{- end }}
             {{- if .Values.mcp.ssl.enabled }}
             - name: MCP_SSL_KEYFILE
               value: {{ .Values.mcp.ssl.keyFile | quote }}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -109,14 +109,16 @@ spec:
             - name: AUTH_PROVIDER
               value: {{ $authProvider | quote }}
             {{- end }}
-            {{- if and (eq $authProvider "static") (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
+            {{- $staticAuth := eq (include "mcp-pinot.authHas" (dict "root" . "name" "static")) "true" }}
+            {{- $oauthAuth := eq (include "mcp-pinot.authHas" (dict "root" . "name" "oauth")) "true" }}
+            {{- if and $staticAuth (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
             - name: MCP_STATIC_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mcp-pinot.fullname" . }}-secrets
                   key: static-token
             {{- end }}
-            {{- if eq $authProvider "static" }}
+            {{- if $staticAuth }}
             - name: MCP_STATIC_SCOPES
               value: {{ join " " .Values.mcp.auth.staticScopes | quote }}
             {{- end }}
@@ -124,7 +126,7 @@ spec:
             # OAuth Configuration
             - name: OAUTH_ENABLED
               value: {{ .Values.mcp.oauth.enabled | quote }}
-            {{- if eq $authProvider "oauth" }}
+            {{- if $oauthAuth }}
             - name: OAUTH_AUTHORIZATION_ENDPOINT
               value: {{ .Values.mcp.oauth.upstreamAuthorizationEndpoint | quote }}
             - name: OAUTH_TOKEN_ENDPOINT

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -172,11 +172,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - python
-                - -c
-                - "import sys, urllib.request; sys.exit(0 if urllib.request.urlopen(sys.argv[1], timeout=float(sys.argv[2])).status == 200 else 1)"
-                - {{ printf "http://127.0.0.1:%v%s" .Values.healthCheck.liveness.port .Values.healthCheck.liveness.path | quote }}
-                - {{ .Values.healthCheck.liveness.timeoutSeconds | quote }}
+                {{- include "mcp-pinot.probeCommand" (dict "root" . "check" .Values.healthCheck.liveness) | nindent 16 }}
             initialDelaySeconds: {{ .Values.healthCheck.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}
@@ -187,11 +183,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                - python
-                - -c
-                - "import sys, urllib.request; sys.exit(0 if urllib.request.urlopen(sys.argv[1], timeout=float(sys.argv[2])).status == 200 else 1)"
-                - {{ printf "http://127.0.0.1:%v%s" .Values.healthCheck.readiness.port .Values.healthCheck.readiness.path | quote }}
-                - {{ .Values.healthCheck.readiness.timeoutSeconds | quote }}
+                {{- include "mcp-pinot.probeCommand" (dict "root" . "check" .Values.healthCheck.readiness) | nindent 16 }}
             initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - name: AUTH_PROVIDER
               value: {{ $authProvider | quote }}
             {{- end }}
-            {{- if and (eq $authProvider "static") .Values.mcp.auth.staticToken }}
+            {{- if eq $authProvider "static" }}
             - name: MCP_STATIC_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -139,6 +139,10 @@ spec:
             - name: OAUTH_AUDIENCE
               value: {{ .Values.mcp.oauth.audience | quote }}
             {{- end }}
+            {{- if .Values.mcp.oauth.grantedScopes }}
+            - name: OAUTH_GRANTED_SCOPES
+              value: {{ join " " .Values.mcp.oauth.grantedScopes | quote }}
+            {{- end }}
             {{- if .Values.mcp.oauth.extraAuthorizeParams }}
             - name: OAUTH_EXTRA_AUTH_PARAMS
               value: {{ .Values.mcp.oauth.extraAuthorizeParams | toJson | quote }}

--- a/helm/mcp-pinot/templates/deployment.yaml
+++ b/helm/mcp-pinot/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - name: AUTH_PROVIDER
               value: {{ $authProvider | quote }}
             {{- end }}
-            {{- if eq $authProvider "static" }}
+            {{- if and (eq $authProvider "static") (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
             - name: MCP_STATIC_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- $oauthEnabled := eq (include "mcp-pinot.authProvider" .) "oauth" }}
-{{- if or .Values.pinot.auth.enabled $oauthEnabled .Values.mcp.auth.staticToken }}
+{{- $staticEnabled := eq (include "mcp-pinot.authProvider" .) "static" }}
+{{- if or .Values.pinot.auth.enabled $oauthEnabled $staticEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,7 +25,7 @@ data:
   oauth-client-secret: {{ .Values.mcp.oauth.clientSecret | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if .Values.mcp.auth.staticToken }}
-  static-token: {{ .Values.mcp.auth.staticToken | b64enc | quote }}
+  {{- if $staticEnabled }}
+  static-token: {{ include "mcp-pinot.staticToken" . | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,5 +1,5 @@
-{{- $oauthEnabled := eq (include "mcp-pinot.authProvider" .) "oauth" }}
-{{- $staticEnabled := and (eq (include "mcp-pinot.authProvider" .) "static") (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
+{{- $oauthEnabled := eq (include "mcp-pinot.authHas" (dict "root" . "name" "oauth")) "true" }}
+{{- $staticEnabled := and (eq (include "mcp-pinot.authHas" (dict "root" . "name" "static")) "true") (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
 {{- if or .Values.pinot.auth.enabled $oauthEnabled $staticEnabled }}
 apiVersion: v1
 kind: Secret

--- a/helm/mcp-pinot/templates/secret.yaml
+++ b/helm/mcp-pinot/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- $oauthEnabled := eq (include "mcp-pinot.authProvider" .) "oauth" }}
-{{- $staticEnabled := eq (include "mcp-pinot.authProvider" .) "static" }}
+{{- $staticEnabled := and (eq (include "mcp-pinot.authProvider" .) "static") (ne (include "mcp-pinot.staticTokenFromEnv" .) "true") }}
 {{- if or .Values.pinot.auth.enabled $oauthEnabled $staticEnabled }}
 apiVersion: v1
 kind: Secret

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -157,6 +157,12 @@ mcp:
       - pinot:write
       - pinot:admin
   oauth:
+    # Pinot scopes granted to every principal the OIDC provider authenticates,
+    # unioned onto the scopes the token already carries. Empty means the server
+    # default (pinot:read, pinot:write, pinot:admin). Set to [pinot:read] for a
+    # read-only deployment. Needed because general-purpose OIDC providers issue a
+    # fixed scope catalog and cannot mint pinot:* themselves.
+    grantedScopes: []
     # Legacy alias for mcp.auth.provider=oauth.
     enabled: false
     clientId: ""

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -147,10 +147,11 @@ mcp:
     keyFile: "/etc/ssl/tls.key"
     certFile: "/etc/ssl/tls.crt"
   auth:
-    # Auth provider for the MCP HTTP endpoint: "" (unset), "none", "oauth", or
-    # "static". Takes precedence over the legacy mcp.oauth.enabled flag.
-    # "" and "none" both mean unauthenticated and do not satisfy the
-    # non-loopback exposure gate.
+    # Auth provider for the MCP HTTP endpoint: "" (unset), "none", "oauth",
+    # "static", or "oauth+static" to accept both an OIDC login and the shared
+    # backend token on the same deployment. Takes precedence over the legacy
+    # mcp.oauth.enabled flag. "" and "none" both mean unauthenticated and do not
+    # satisfy the non-loopback exposure gate.
     provider: ""
     # Shared bearer token for provider=static (service-to-service callers).
     # Rendered into the chart Secret and mounted as MCP_STATIC_TOKEN.

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -143,8 +143,12 @@ mcp:
     # non-loopback exposure gate.
     provider: ""
     # Shared bearer token for provider=static (service-to-service callers).
-    # Rendered into the chart Secret, mounted as MCP_STATIC_TOKEN. Leave empty
-    # to supply MCP_STATIC_TOKEN yourself via env.additional.
+    # Rendered into the chart Secret and mounted as MCP_STATIC_TOKEN.
+    # Leave EMPTY to auto-generate: with provider=static the chart mints a random
+    # token on first install and persists it in the Secret, reusing it on every
+    # upgrade via lookup, so no operator has to pick, paste, or distribute one and
+    # each environment gets a distinct token. Consumers read it from the Secret
+    # (key static-token). Set explicitly only to pin a known value.
     staticToken: ""
     # Scopes granted to the shared service principal. Remove write/admin for a
     # read-only deployment.

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -132,6 +132,16 @@ mcp:
   host: "127.0.0.1"
   port: 8000
   path: "/mcp"
+  # Exact Host authorities accepted at the MCP endpoint (MCP_ALLOWED_HOSTS).
+  # REQUIRED whenever mcp.host is a wildcard bind such as 0.0.0.0: the server has
+  # no way to infer its public authority and exits at startup rather than accepting
+  # any Host. Use the names clients actually connect to, including the port when
+  # clients send one, e.g. [mcp.example.com, mcp.example.com:443].
+  allowedHosts: []
+  # Exact browser Origin values accepted (MCP_ALLOWED_ORIGINS). Empty rejects
+  # requests that send Origin while still allowing clients that omit it, which is
+  # the right default for non-browser MCP clients.
+  allowedOrigins: []
   ssl:
     enabled: false
     keyFile: "/etc/ssl/tls.key"

--- a/helm/mcp-pinot/values.yaml
+++ b/helm/mcp-pinot/values.yaml
@@ -200,7 +200,12 @@ pinot:
     token: ""
     tokenFilename: ""
 
-# Health check configuration
+# Health check configuration. The probes exec a local HTTP(S) request against
+# /livez and /readyz; the scheme follows mcp.ssl.enabled, and certificate
+# verification is skipped for that loopback check only (the certificate is issued
+# for the public names, not 127.0.0.1). Those two routes sit outside the MCP path,
+# so neither the Host allowlist nor the auth provider applies to them — probes work
+# with any auth configuration.
 healthCheck:
   liveness:
     enabled: true

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -72,6 +72,16 @@ matches "static-token:" && fail "unused static-token key rendered"
 [ "$(printf '%s' "$out" | grep -c 'name: MCP_STATIC_TOKEN')" = "1" ] \
   || fail "MCP_STATIC_TOKEN not declared exactly once"
 
+# Health probes must speak the scheme the server actually serves; an http:// probe
+# against a TLS listener fails forever.
+out=$(render_exposed --set mcp.auth.provider=static --set mcp.ssl.enabled=true)
+matches 'https://127.0.0.1:8000/livez' || fail "liveness probe not using https with mcp.ssl.enabled"
+matches 'https://127.0.0.1:8000/readyz' || fail "readiness probe not using https with mcp.ssl.enabled"
+matches '_create_unverified_context' || fail "loopback https probe must skip cert verification"
+out=$(render_exposed --set mcp.auth.provider=static)
+matches 'http://127.0.0.1:8000/livez' || fail "liveness probe not using http without TLS"
+matches 'https://127.0.0.1' && fail "https probe rendered without mcp.ssl.enabled"
+
 # A wildcard bind needs an explicit Host allowlist: the chart refuses to render
 # rather than letting the server exit at startup.
 if render --set service.enabled=true --set mcp.host=0.0.0.0 \

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -105,6 +105,18 @@ out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
   --set 'env.additional[0].value=mcp.example.com')
 matches 'name: MCP_ALLOWED_HOSTS' || fail "external MCP_ALLOWED_HOSTS missing"
 
+# provider=oauth+static wires BOTH credential types on one deployment.
+out=$(render_exposed \
+  --set mcp.auth.provider=oauth+static --set mcp.oauth.clientSecret=cs3cret \
+  --set 'mcp.auth.staticScopes={pinot:read}' \
+  --set 'mcp.oauth.grantedScopes={pinot:read,pinot:write}')
+matches 'value: "oauth+static"' || fail "composite AUTH_PROVIDER not rendered"
+matches 'name: MCP_STATIC_TOKEN' || fail "static token missing under oauth+static"
+matches 'name: OAUTH_ISSUER' || fail "OAuth block missing under oauth+static"
+matches 'value: "pinot:read pinot:write"' || fail "granted scopes missing under oauth+static"
+matches 'key: static-token' || fail "static-token ref missing under oauth+static"
+matches 'key: oauth-client-secret' || fail "oauth-client-secret ref missing under oauth+static"
+
 # provider=oauth with a narrowed grant renders the read-only scope set.
 out=$(render_exposed \
   --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret \

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -6,6 +6,13 @@ CHART="$(dirname "$0")/mcp-pinot"
 
 render() { helm template smoke "$CHART" "$@"; }
 
+# Exposed renders need a Host allowlist (see the wildcard-bind guard below); this
+# keeps each case focused on the behaviour it is named for.
+render_exposed() {
+  render --set service.enabled=true --set mcp.host=0.0.0.0 \
+    --set 'mcp.allowedHosts={mcp.example.com}' "$@"
+}
+
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 # Avoid Bash here-strings, which allocate temporary files and can make these
@@ -35,7 +42,7 @@ matches 'requests:' || fail "resource requests missing"
 matches 'limits:' || fail "resource limits missing"
 
 # provider=static: AUTH_PROVIDER + MCP_STATIC_TOKEN from the chart Secret.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=static --set mcp.auth.staticToken=s3cret)
 matches 'name: AUTH_PROVIDER' || fail "AUTH_PROVIDER not rendered"
 matches 'value: "static"' || fail "AUTH_PROVIDER value wrong"
@@ -47,7 +54,7 @@ matches "static-token: \"$(printf s3cret | base64)\"" || fail "static-token not 
 
 # provider=static with no staticToken: the chart mints and persists one, so the
 # install is usable without an operator choosing or pasting a secret.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=static)
 matches 'name: MCP_STATIC_TOKEN' || fail "auto-generated MCP_STATIC_TOKEN not wired"
 matches 'key: static-token' || fail "auto-generated static-token ref missing"
@@ -56,7 +63,7 @@ matches 'static-token: "[A-Za-z0-9+/=]\{32,\}"' || fail "auto-generated static-t
 # provider=static with the token supplied through env.additional: the chart stays
 # out of the way, so MCP_STATIC_TOKEN is declared exactly once and no unused
 # secret material is stored.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=static \
   --set 'env.additional[0].name=MCP_STATIC_TOKEN' \
   --set 'env.additional[0].value=external' )
@@ -65,20 +72,43 @@ matches "static-token:" && fail "unused static-token key rendered"
 [ "$(printf '%s' "$out" | grep -c 'name: MCP_STATIC_TOKEN')" = "1" ] \
   || fail "MCP_STATIC_TOKEN not declared exactly once"
 
-# provider=oauth with a narrowed grant renders the read-only scope set.
+# A wildcard bind needs an explicit Host allowlist: the chart refuses to render
+# rather than letting the server exit at startup.
+if render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static >/dev/null 2>&1; then
+  fail "wildcard bind rendered without mcp.allowedHosts"
+fi
+
+# ... and renders MCP_ALLOWED_HOSTS/ORIGINS once supplied.
 out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static \
+  --set 'mcp.allowedHosts={mcp.example.com,mcp.example.com:443}' \
+  --set 'mcp.allowedOrigins={https://mcp.example.com}')
+matches 'name: MCP_ALLOWED_HOSTS' || fail "MCP_ALLOWED_HOSTS not rendered"
+matches 'value: "mcp.example.com,mcp.example.com:443"' || fail "allowed hosts value wrong"
+matches 'name: MCP_ALLOWED_ORIGINS' || fail "MCP_ALLOWED_ORIGINS not rendered"
+
+# An allowlist supplied through env.additional satisfies the guard too.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static \
+  --set 'env.additional[0].name=MCP_ALLOWED_HOSTS' \
+  --set 'env.additional[0].value=mcp.example.com')
+matches 'name: MCP_ALLOWED_HOSTS' || fail "external MCP_ALLOWED_HOSTS missing"
+
+# provider=oauth with a narrowed grant renders the read-only scope set.
+out=$(render_exposed \
   --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret \
   --set 'mcp.oauth.grantedScopes={pinot:read}')
 matches 'name: OAUTH_GRANTED_SCOPES' || fail "OAUTH_GRANTED_SCOPES not rendered"
 matches 'value: "pinot:read"' || fail "granted scopes value wrong"
 
 # ... and omits it entirely when unset, leaving the server default in place.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret)
 matches 'name: OAUTH_GRANTED_SCOPES' && fail "OAUTH_GRANTED_SCOPES rendered when unset"
 
 # provider=oauth alone wires the full OAuth env block and Secret key.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret)
 matches 'value: "oauth"' || fail "AUTH_PROVIDER=oauth not rendered"
 matches 'name: OAUTH_ISSUER' || fail "OAUTH_* block missing for provider=oauth"
@@ -86,14 +116,14 @@ matches 'key: oauth-client-secret' || fail "oauth-client-secret ref missing"
 matches "oauth-client-secret: \"$(printf cs3cret | base64)\"" || fail "oauth-client-secret not in Secret"
 
 # Legacy oauth.enabled=true still wires the same block, with no AUTH_PROVIDER.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.oauth.enabled=true)
 matches 'name: OAUTH_ISSUER' || fail "OAUTH_* block missing for legacy flag"
 matches 'name: AUTH_PROVIDER' && fail "legacy flag rendered AUTH_PROVIDER"
 
 # AUTH_PROVIDER renders normalized (trim + lowercase), matching the server's
 # _resolve_auth_provider; a whitespace-only value renders no env var at all.
-out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+out=$(render_exposed \
   --set mcp.auth.provider=" OAuth ")
 matches 'value: "oauth"' || fail "AUTH_PROVIDER not normalized"
 out=$(render --set mcp.auth.provider="   ")

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -45,12 +45,37 @@ matches 'value: "pinot:read pinot:write pinot:admin"' || fail "static scopes val
 matches 'key: static-token' || fail "static-token secretKeyRef missing"
 matches "static-token: \"$(printf s3cret | base64)\"" || fail "static-token not in Secret"
 
-# provider=static with no staticToken: no chart-managed MCP_STATIC_TOKEN, so a
-# token supplied through env.additional is not declared twice.
+# provider=static with no staticToken: the chart mints and persists one, so the
+# install is usable without an operator choosing or pasting a secret.
 out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
   --set mcp.auth.provider=static)
-matches 'name: MCP_STATIC_TOKEN' && fail "MCP_STATIC_TOKEN rendered without a token"
-matches "static-token:" && fail "empty static-token key rendered"
+matches 'name: MCP_STATIC_TOKEN' || fail "auto-generated MCP_STATIC_TOKEN not wired"
+matches 'key: static-token' || fail "auto-generated static-token ref missing"
+matches 'static-token: "[A-Za-z0-9+/=]\{32,\}"' || fail "auto-generated static-token not in Secret"
+
+# provider=static with the token supplied through env.additional: the chart stays
+# out of the way, so MCP_STATIC_TOKEN is declared exactly once and no unused
+# secret material is stored.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=static \
+  --set 'env.additional[0].name=MCP_STATIC_TOKEN' \
+  --set 'env.additional[0].value=external' )
+matches 'key: static-token' && fail "chart minted a token despite an external one"
+matches "static-token:" && fail "unused static-token key rendered"
+[ "$(printf '%s' "$out" | grep -c 'name: MCP_STATIC_TOKEN')" = "1" ] \
+  || fail "MCP_STATIC_TOKEN not declared exactly once"
+
+# provider=oauth with a narrowed grant renders the read-only scope set.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret \
+  --set 'mcp.oauth.grantedScopes={pinot:read}')
+matches 'name: OAUTH_GRANTED_SCOPES' || fail "OAUTH_GRANTED_SCOPES not rendered"
+matches 'value: "pinot:read"' || fail "granted scopes value wrong"
+
+# ... and omits it entirely when unset, leaving the server default in place.
+out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
+  --set mcp.auth.provider=oauth --set mcp.oauth.clientSecret=cs3cret)
+matches 'name: OAUTH_GRANTED_SCOPES' && fail "OAUTH_GRANTED_SCOPES rendered when unset"
 
 # provider=oauth alone wires the full OAuth env block and Secret key.
 out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \

--- a/helm/smoke-test.sh
+++ b/helm/smoke-test.sh
@@ -89,6 +89,12 @@ if render --set service.enabled=true --set mcp.host=0.0.0.0 \
   fail "wildcard bind rendered without mcp.allowedHosts"
 fi
 
+# A concrete non-loopback bind identifies its own authority and therefore does
+# not need the wildcard-only allowlist guard.
+out=$(render --set service.enabled=true --set mcp.host=10.0.0.5 \
+  --set mcp.auth.provider=static)
+matches 'value: "10.0.0.5"' || fail "concrete non-loopback host did not render"
+
 # ... and renders MCP_ALLOWED_HOSTS/ORIGINS once supplied.
 out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
   --set mcp.auth.provider=static \
@@ -102,7 +108,9 @@ matches 'name: MCP_ALLOWED_ORIGINS' || fail "MCP_ALLOWED_ORIGINS not rendered"
 out=$(render --set service.enabled=true --set mcp.host=0.0.0.0 \
   --set mcp.auth.provider=static \
   --set 'env.additional[0].name=MCP_ALLOWED_HOSTS' \
-  --set 'env.additional[0].value=mcp.example.com')
+  --set 'env.additional[0].value=mcp.example.com' \
+  --set 'env.additional[1].name=MCP_ALLOWED_HOSTS' \
+  --set 'env.additional[1].value=mcp.example.com:443')
 matches 'name: MCP_ALLOWED_HOSTS' || fail "external MCP_ALLOWED_HOSTS missing"
 
 # provider=oauth+static wires BOTH credential types on one deployment.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "mcp-pinot",
   "display_name": "Apache Pinot MCP Server",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Explore Apache Pinot with read-only SQL, typed metadata tools, and preview-first configuration changes.",
   "long_description": "This Python MCP server exposes agent-oriented tools for Apache Pinot analytics: discover tables, inspect schemas and segments, run read-only SQL, and preview schema or table-config changes before applying them. It runs over STDIO for desktop MCP hosts and supports Streamable HTTP for authenticated remote deployments.",
   "author": {

--- a/mcp_pinot/auth/__init__.py
+++ b/mcp_pinot/auth/__init__.py
@@ -3,10 +3,10 @@
 The server obtains its auth provider through :func:`build_auth`, which selects a
 provider by name (``ServerConfig.auth_provider``) from a registry. Built-in
 providers are ``none``, ``oauth``, ``static``, and ``oauth+static`` for a
-deployment serving interactive users and one trusted backend at the same time. Additional providers can be
-contributed **without modifying this package** by registering a Python entry
-point in the ``mcp_pinot.auth_providers`` group — for example a private StarTree
-token provider in a downstream fork::
+deployment serving interactive users and one trusted backend at the same time.
+Additional providers can be contributed **without modifying this package** by
+registering a Python entry point in the ``mcp_pinot.auth_providers`` group — for
+example a private StarTree token provider in a downstream fork::
 
     [project.entry-points."mcp_pinot.auth_providers"]
     startree = "startree_mcp_pinot.auth:build_startree_auth"

--- a/mcp_pinot/auth/__init__.py
+++ b/mcp_pinot/auth/__init__.py
@@ -2,7 +2,8 @@
 
 The server obtains its auth provider through :func:`build_auth`, which selects a
 provider by name (``ServerConfig.auth_provider``) from a registry. Built-in
-providers are ``none``, ``oauth`` and ``static``. Additional providers can be
+providers are ``none``, ``oauth``, ``static``, and ``oauth+static`` for a
+deployment serving interactive users and one trusted backend at the same time. Additional providers can be
 contributed **without modifying this package** by registering a Python entry
 point in the ``mcp_pinot.auth_providers`` group — for example a private StarTree
 token provider in a downstream fork::
@@ -20,6 +21,7 @@ from collections.abc import Callable
 from importlib.metadata import entry_points
 from typing import Any
 
+from mcp_pinot.auth.multi import build_oauth_static_auth
 from mcp_pinot.auth.oauth import build_oauth_auth
 from mcp_pinot.auth.static import build_static_auth
 from mcp_pinot.config import ServerConfig, get_logger
@@ -78,13 +80,26 @@ def available_providers() -> list[str]:
     return sorted(_PROVIDERS)
 
 
+def _canonical_name(raw: str) -> str:
+    """Normalise a provider name, so ``a+b`` and ``b+a`` select the same provider.
+
+    Composite names describe a *set* of accepted credential types; the order a
+    caller writes them in carries no meaning (verification order is the provider's
+    own concern).
+    """
+    parts = [part.strip() for part in raw.split("+") if part.strip()]
+    if len(parts) <= 1:
+        return raw.strip()
+    return "+".join(sorted(dict.fromkeys(parts)))
+
+
 def build_auth(server_config: ServerConfig) -> "AuthProvider | None":
     """Build the auth provider selected by ``server_config.auth_provider``.
 
     Returns ``None`` (no authentication) when no provider is selected or the
     selected provider is ``none``. Raises ``ValueError`` for an unknown provider.
     """
-    name = (server_config.auth_provider or "none").lower()
+    name = _canonical_name((server_config.auth_provider or "none").lower())
     if name == "none":
         return None
 
@@ -102,3 +117,6 @@ def build_auth(server_config: ServerConfig) -> "AuthProvider | None":
 register_auth_provider("none", _build_none)
 register_auth_provider("oauth", build_oauth_auth)
 register_auth_provider("static", build_static_auth)
+# Both credential types on one deployment. Registered under the canonical
+# (alphabetically sorted) name; "static+oauth" normalises to this.
+register_auth_provider("oauth+static", build_oauth_static_auth)

--- a/mcp_pinot/auth/multi.py
+++ b/mcp_pinot/auth/multi.py
@@ -1,0 +1,93 @@
+"""Accept more than one kind of credential on a single MCP deployment.
+
+A hosted deployment usually has two kinds of caller at once:
+
+* **people**, whose MCP client completes the OIDC flow and arrives with a token
+  from the environment's identity provider, and
+* **one trusted backend** (an agent service, or a gateway calling as itself),
+  which cannot run a browser flow and holds a shared secret instead.
+
+Selecting a single provider forces a choice between them, and there is no clean
+workaround: a second deployment means a second hostname and certificate, and many
+identity providers cannot issue the client-credentials grant a backend would need.
+
+So ``AUTH_PROVIDER=oauth+static`` builds the OAuth provider — which owns the
+discovery, registration and authorization routes people need — and gives it a
+:class:`ChainedTokenVerifier` that recognises the shared secret as well as an OIDC
+token. Both spellings (``static+oauth``) select the same thing; the shared secret is
+always tried first because that check is a constant-time comparison, while the OIDC
+path may fetch signing keys.
+
+Each credential keeps its own authorization: the shared secret carries
+``MCP_STATIC_SCOPES`` and an OIDC user carries ``OAUTH_GRANTED_SCOPES``, so a
+backend can be read-only while people retain write access, or the reverse. The
+principals stay distinguishable in logs by ``client_id``.
+"""
+
+from collections.abc import Sequence
+
+from fastmcp.server.auth import OAuthProxy
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+
+from mcp_pinot.auth.oauth import build_token_verifier
+from mcp_pinot.auth.static import build_static_auth
+from mcp_pinot.config import ServerConfig, get_logger, load_oauth_config
+
+logger = get_logger()
+
+
+class ChainedTokenVerifier(TokenVerifier):
+    """Verify a bearer token against several verifiers, in order.
+
+    The first verifier that recognises the token decides the request, including
+    the scopes the resulting principal holds. A token no verifier recognises is
+    rejected exactly as a single verifier would reject it.
+    """
+
+    def __init__(self, verifiers: Sequence[TokenVerifier]) -> None:
+        if not verifiers:
+            raise ValueError("ChainedTokenVerifier requires at least one verifier.")
+        # Advertise the union of nothing: per-tool Pinot scopes are enforced on the
+        # component, and a baseline shared by unrelated credential types would
+        # reject one of them. Individual verifiers keep their own required_scopes.
+        super().__init__(required_scopes=None)
+        self._verifiers = list(verifiers)
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        for verifier in self._verifiers:
+            access_token = await verifier.verify_token(token)
+            if access_token is not None:
+                return access_token
+        return None
+
+
+def build_oauth_static_auth(server_config: ServerConfig) -> OAuthProxy:
+    """Build the OAuth provider, additionally accepting the static shared token.
+
+    Fails at startup if either half is misconfigured — a deployment that asked for
+    both should not silently come up supporting one.
+    """
+    static_verifier = build_static_auth(server_config)
+    oauth_config = load_oauth_config()
+    oidc_verifier = build_token_verifier(oauth_config, server_config.path)
+
+    logger.info(
+        "Auth accepts two credential types: the static shared token (scopes: %s) "
+        "and %s-issued tokens (granted scopes: %s).",
+        " ".join(static_verifier.tokens[next(iter(static_verifier.tokens))]["scopes"]),
+        oauth_config.issuer,
+        " ".join(oauth_config.granted_scopes or []),
+    )
+
+    return OAuthProxy(
+        upstream_authorization_endpoint=oauth_config.upstream_authorization_endpoint,
+        upstream_token_endpoint=oauth_config.upstream_token_endpoint,
+        upstream_client_id=oauth_config.client_id,
+        upstream_client_secret=oauth_config.client_secret,
+        # Shared secret first: a constant-time comparison, and it avoids a signing-key
+        # fetch for the backend caller that sends it on every request.
+        token_verifier=ChainedTokenVerifier([static_verifier, oidc_verifier]),
+        extra_authorize_params=oauth_config.extra_authorize_params,
+        base_url=oauth_config.base_url,
+        valid_scopes=oauth_config.scopes,
+    )

--- a/mcp_pinot/auth/oauth.py
+++ b/mcp_pinot/auth/oauth.py
@@ -5,30 +5,97 @@ upstream OIDC provider, validating JWT access tokens via :class:`JWTVerifier`. I
 is registered as the ``oauth`` auth provider (see :mod:`mcp_pinot.auth`).
 """
 
+import logging
+from typing import Any
+
 from fastmcp.server.auth import OAuthProxy
+from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 
-from mcp_pinot.config import ServerConfig, load_oauth_config
+from mcp_pinot.config import OAuthConfig, ServerConfig, load_oauth_config
+
+logger = logging.getLogger(__name__)
+
+
+class PinotScopeGrantingVerifier(JWTVerifier):
+    """JWT verifier that grants configured Pinot scopes to valid principals.
+
+    Every tool, resource, and prompt is gated on ``pinot:read``/``pinot:write``/
+    ``pinot:admin``. Those are resource-specific authorization scopes, and a
+    general-purpose OIDC provider issues a fixed catalog it cannot extend — Dex,
+    for instance, accepts only ``openid``, ``profile``, ``email``, ``groups``,
+    ``offline_access`` and its cross-client audience scope, rejecting anything
+    else. Without a grant, a correctly authenticated user's token would carry no
+    Pinot scope at all and every tool call would be denied.
+
+    So the deployment decides what an authenticated principal may do:
+    ``OAUTH_GRANTED_SCOPES`` (default: all three) is unioned onto whatever the
+    token already carries. Set it to ``pinot:read`` for a read-only deployment —
+    the mutating tools are then rejected for every OIDC caller. Scopes a token
+    genuinely carries are always preserved, so a provider that *can* mint Pinot
+    scopes keeps working and a narrower grant never revokes them.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        granted_scopes: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._granted_scopes = list(granted_scopes or [])
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        access_token = await super().verify_token(token)
+        if access_token is None or not self._granted_scopes:
+            return access_token
+        merged = list(dict.fromkeys([*access_token.scopes, *self._granted_scopes]))
+        if merged == list(access_token.scopes):
+            return access_token
+        return access_token.model_copy(update={"scopes": merged})
+
+
+def build_token_verifier(
+    oauth_config: OAuthConfig, mcp_path: str
+) -> PinotScopeGrantingVerifier:
+    """Build the access-token verifier for the OAuth provider.
+
+    Split out from :func:`build_oauth_auth` because the audience resolution and the
+    scope grant are the parts worth exercising directly — ``OAuthProxy`` keeps its
+    verifier private.
+    """
+    canonical_resource = f"{oauth_config.base_url.rstrip('/')}{mcp_path}"
+    audience = oauth_config.audience or canonical_resource
+    if audience != canonical_resource:
+        # Allowed, but worth saying out loud: RFC 9728 metadata advertises the
+        # canonical resource URI while tokens are validated against a different
+        # audience. Providers that set `aud` to the client ID (Dex among them)
+        # require exactly this, so it is a warning rather than a hard failure.
+        logger.warning(
+            "OAUTH_AUDIENCE (%r) differs from the canonical MCP resource URI (%r). "
+            "Tokens are validated against OAUTH_AUDIENCE, while the resource URI is "
+            "what RFC 9728 metadata advertises. Point OAUTH_AUDIENCE at the resource "
+            "URI if your provider can issue that audience.",
+            audience,
+            canonical_resource,
+        )
+
+    return PinotScopeGrantingVerifier(
+        jwks_uri=oauth_config.jwks_uri,
+        issuer=oauth_config.issuer,
+        audience=audience,
+        # Optional baseline scopes are enforced here; component-level Pinot scopes
+        # are independently enforced for every tool/resource/prompt.
+        required_scopes=oauth_config.required_scopes,
+        # Pinot scopes granted to any principal this provider authenticates.
+        granted_scopes=oauth_config.granted_scopes,
+    )
 
 
 def build_oauth_auth(server_config: ServerConfig) -> OAuthProxy:
     """Build the OAuthProxy auth provider from environment configuration."""
     oauth_config = load_oauth_config()
-    expected_audience = f"{oauth_config.base_url.rstrip('/')}{server_config.path}"
-    if oauth_config.audience != expected_audience:
-        raise ValueError(
-            "OAUTH_AUDIENCE must exactly match the canonical MCP resource URI "
-            f"({expected_audience!r}) so token validation and RFC 9728 metadata agree."
-        )
-
-    token_verifier = JWTVerifier(
-        jwks_uri=oauth_config.jwks_uri,
-        issuer=oauth_config.issuer,
-        audience=oauth_config.audience,
-        # Optional baseline scopes are enforced here; component-level Pinot scopes
-        # are independently enforced for every tool/resource/prompt.
-        required_scopes=oauth_config.required_scopes,
-    )
+    token_verifier = build_token_verifier(oauth_config, server_config.path)
 
     return OAuthProxy(
         upstream_authorization_endpoint=oauth_config.upstream_authorization_endpoint,

--- a/mcp_pinot/config.py
+++ b/mcp_pinot/config.py
@@ -125,6 +125,12 @@ class OAuthConfig:
     extra_authorize_params: dict[str, str] | None = None
     scopes: list[str] | None = None  # advertised OAuth scope catalog
     required_scopes: list[str] | None = None  # optional global baseline scopes
+    # Pinot authorization scopes granted to every principal this provider
+    # authenticates. Most OIDC providers issue a fixed scope catalog and cannot
+    # mint resource-specific scopes such as pinot:read, so without a grant the
+    # per-tool scope checks would reject every call from a valid user. Narrow this
+    # to ["pinot:read"] for a read-only deployment.
+    granted_scopes: list[str] | None = None
 
 
 def _parse_broker_url(broker_url: str) -> tuple[str, int, str]:
@@ -474,6 +480,27 @@ def _parse_optional_scopes(raw: str | None) -> list[str] | None:
     return [scope for scope in scopes if scope] or None
 
 
+def _parse_pinot_scopes(raw: str | None, env_name: str) -> list[str]:
+    """Parse a Pinot-authorization scope list, validating every entry.
+
+    Shared by ``MCP_STATIC_SCOPES`` and ``OAUTH_GRANTED_SCOPES``: both name the
+    Pinot scopes a principal is granted, so both reject anything outside
+    :data:`PINOT_AUTHORIZATION_SCOPES` rather than silently granting nothing.
+    Falls back to the full set when unset/empty.
+    """
+    if not raw or not raw.strip():
+        return ["pinot:read", "pinot:write", "pinot:admin"]
+    scopes = list(dict.fromkeys(raw.replace(",", " ").split()))
+    invalid = sorted(set(scopes) - PINOT_AUTHORIZATION_SCOPES)
+    if invalid:
+        raise ValueError(
+            f"{env_name} contains unsupported scopes: " + ", ".join(invalid)
+        )
+    if not scopes:
+        raise ValueError(f"{env_name} must grant at least one Pinot scope.")
+    return scopes
+
+
 def load_static_token() -> str:
     """Return the shared bearer secret for the ``static`` auth provider.
 
@@ -493,18 +520,7 @@ def load_static_token() -> str:
 
 def load_static_scopes() -> list[str]:
     """Return explicit scopes granted to the shared static service principal."""
-    raw = os.getenv("MCP_STATIC_SCOPES")
-    if not raw or not raw.strip():
-        return ["pinot:read", "pinot:write", "pinot:admin"]
-    scopes = list(dict.fromkeys(raw.replace(",", " ").split()))
-    invalid = sorted(set(scopes) - PINOT_AUTHORIZATION_SCOPES)
-    if invalid:
-        raise ValueError(
-            "MCP_STATIC_SCOPES contains unsupported scopes: " + ", ".join(invalid)
-        )
-    if not scopes:
-        raise ValueError("MCP_STATIC_SCOPES must grant at least one Pinot scope.")
-    return scopes
+    return _parse_pinot_scopes(os.getenv("MCP_STATIC_SCOPES"), "MCP_STATIC_SCOPES")
 
 
 def load_oauth_config() -> OAuthConfig:
@@ -539,7 +555,11 @@ def load_oauth_config() -> OAuthConfig:
         "issuer": os.getenv("OAUTH_ISSUER", "").strip(),
         "audience": os.getenv("OAUTH_AUDIENCE", "").strip(),
     }
-    missing = [name for name, value in values.items() if not value]
+    # OAUTH_AUDIENCE is optional: when unset, build_oauth_auth() defaults it to the
+    # canonical MCP resource URI, which is what RFC 9728 metadata advertises.
+    missing = [
+        name for name, value in values.items() if not value and name != "audience"
+    ]
     if missing:
         env_by_field = {
             "client_id": "OAUTH_CLIENT_ID",
@@ -549,7 +569,6 @@ def load_oauth_config() -> OAuthConfig:
             "upstream_token_endpoint": "OAUTH_TOKEN_ENDPOINT",
             "jwks_uri": "OAUTH_JWKS_URI",
             "issuer": "OAUTH_ISSUER",
-            "audience": "OAUTH_AUDIENCE",
         }
         env_names = ", ".join(env_by_field[name] for name in missing)
         raise ValueError(f"OAuth configuration is incomplete; missing: {env_names}.")
@@ -575,4 +594,7 @@ def load_oauth_config() -> OAuthConfig:
         extra_authorize_params=extra_authorize_params,
         scopes=_parse_oauth_scopes(os.getenv("OAUTH_SCOPES")),
         required_scopes=_parse_optional_scopes(os.getenv("OAUTH_REQUIRED_SCOPES")),
+        granted_scopes=_parse_pinot_scopes(
+            os.getenv("OAUTH_GRANTED_SCOPES"), "OAUTH_GRANTED_SCOPES"
+        ),
     )

--- a/mcp_pinot/models.py
+++ b/mcp_pinot/models.py
@@ -160,16 +160,34 @@ class ConnectionDiagnostics(BaseModel):
     """
 
     connection_test: bool = Field(
-        default=False, description="True when a broker connection was established."
+        default=False,
+        description=(
+            "True when the broker answered, i.e. the query check below succeeded."
+        ),
     )
     query_test: bool = Field(
-        default=False, description="True when a trivial 'SELECT 1' succeeded."
+        default=False,
+        description=(
+            "True when a trivial 'SELECT 1' succeeded through the same broker path "
+            "read_query uses."
+        ),
     )
     tables_test: bool = Field(
         default=False, description="True when the controller table listing succeeded."
     )
+    dbapi_test: bool = Field(
+        default=False,
+        description=(
+            "Informational: True when the optional pinotdb DB-API probe also "
+            "succeeded. No tool uses that path, so false here does not mean the "
+            "deployment is unhealthy — check query_test and tables_test instead."
+        ),
+    )
     error: str | None = Field(
-        default=None, description="Error message when a check failed, else null."
+        default=None,
+        description=(
+            "Names the checks that failed, or null when both required checks passed."
+        ),
     )
     tables_count: int | None = Field(
         default=None, description="Number of tables discovered, when available."

--- a/mcp_pinot/pinot_client.py
+++ b/mcp_pinot/pinot_client.py
@@ -591,11 +591,25 @@ class PinotClient:
             return self._conn
 
     def test_connection(self) -> dict[str, Any]:
-        """Test the connection and return diagnostic information"""
+        """Test connectivity the way the tools use it and return diagnostics.
+
+        Each check runs independently and through the same code path as the tool it
+        stands in for — the query check via :meth:`execute_query` (what
+        ``read_query`` uses) and the listing check via :meth:`get_tables` (what
+        ``list_tables`` uses). An earlier version probed through the pinotdb DB-API
+        connection instead, which no tool uses: against a broker whose response
+        pinotdb rejects (``check_sufficient_responded``) it reported every check
+        failed on a deployment where every tool worked, sending operators to chase
+        endpoints and credentials that were fine.
+
+        The DB-API probe is still run, but only as an informational ``dbapi_test``
+        signal: it never decides whether the deployment is healthy.
+        """
         result: dict[str, Any] = {
             "connection_test": False,
             "query_test": False,
             "tables_test": False,
+            "dbapi_test": False,
             "error": None,
             "config": {
                 "broker_host": self.config.broker_host,
@@ -614,30 +628,54 @@ class PinotClient:
             },
         }
 
+        failed: list[str] = []
+
+        # Broker query check — the path read_query takes. A successful query also
+        # proves the broker connection, so connection_test is derived from it
+        # rather than from a separate client the tools never use.
         try:
-            # Test basic connection
-            conn = self.get_connection()
+            result["query_result"] = self.execute_query(
+                "SELECT 1 AS test_column", max_rows=1
+            )
             result["connection_test"] = True
-
-            # Test simple query
-            curs = conn.cursor()
-            curs.execute("SELECT 1 as test_column")
-            test_result = curs.fetchall()
             result["query_test"] = True
-            result["query_result"] = test_result
+        except Exception as e:
+            logger.error("Connection test: broker query failed: %s", e, exc_info=True)
+            failed.append("broker query")
 
-            # Test tables listing
+        # Controller listing check — the path list_tables takes.
+        try:
             tables = self.get_tables()
             result["tables_test"] = True
             result["tables_count"] = len(tables)
             result["sample_tables"] = tables[:5] if tables else []
-
         except Exception as e:
-            result["error"] = (
-                "Pinot connectivity check failed. Verify endpoints, credentials, "
-                "and network access; consult server logs for the correlation detail."
+            logger.error(
+                "Connection test: controller table listing failed: %s", e, exc_info=True
             )
-            logger.error("Connection test failed: %s", e, exc_info=True)
+            failed.append("controller table listing")
+
+        # Informational only: some brokers return responses the pinotdb DB-API
+        # rejects even though the REST path the tools use works fine.
+        try:
+            cursor = self.get_connection().cursor()
+            cursor.execute("SELECT 1")
+            cursor.fetchall()
+            result["dbapi_test"] = True
+        except Exception as e:
+            logger.info(
+                "Connection test: optional pinotdb DB-API probe failed "
+                "(does not affect any tool): %s",
+                e,
+            )
+
+        if failed:
+            result["error"] = (
+                "Pinot connectivity check failed for: "
+                + ", ".join(failed)
+                + ". Verify endpoints, credentials, and network access; consult "
+                "server logs for the correlation detail."
+            )
 
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-pinot-server"
-version = "4.0.0"
+version = "4.1.0"
 description = "A production-grade MCP server for Apache Pinot"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/prepare_registry_metadata.py
+++ b/scripts/prepare_registry_metadata.py
@@ -1,0 +1,69 @@
+"""Prepare canonical MCP Registry package metadata for a release tag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+
+def _canonical_oci_identifier(identifier: str, version: str) -> str:
+    """Return an OCI reference whose release is encoded only in its tag."""
+    reference = identifier.split("@", 1)[0]
+    namespace, separator, image = reference.rpartition("/")
+    if not separator or not namespace or not image:
+        raise ValueError(f"Invalid OCI identifier: {identifier!r}")
+    image = image.rsplit(":", 1)[0]
+    if not image:
+        raise ValueError(f"Invalid OCI identifier: {identifier!r}")
+    return f"{namespace}/{image}:{version}"
+
+
+def prepare_metadata(path: Path, release_tag: str) -> tuple[str, str]:
+    """Update server and package versions using registry-specific conventions."""
+    server_version = release_tag[1:] if release_tag.startswith("v") else release_tag
+    try:
+        package_version = str(Version(server_version))
+    except InvalidVersion as exc:
+        raise ValueError(
+            f"Release tag {release_tag!r} is not a valid package version: {exc}"
+        ) from exc
+
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    metadata["version"] = server_version
+    for package in metadata.get("packages", []):
+        if package.get("registryType") == "oci":
+            package["identifier"] = _canonical_oci_identifier(
+                package.get("identifier", ""), package_version
+            )
+            package.pop("registryBaseUrl", None)
+            package.pop("version", None)
+            package.pop("fileSha256", None)
+        else:
+            package["version"] = package_version
+
+    path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    return server_version, package_version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("release_tag")
+    parser.add_argument("--path", type=Path, default=Path("server.json"))
+    args = parser.parse_args()
+
+    server_version, package_version = prepare_metadata(args.path, args.release_tag)
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as output:
+            print(f"server_version={server_version}", file=output)
+            print(f"package_version={package_version}", file=output)
+    print(f"Set MCP Registry version to {server_version}")
+    print(f"Set package version to {package_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server.json
+++ b/server.json
@@ -69,9 +69,7 @@
     },
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
-      "identifier": "ghcr.io/startreedata/mcp-pinot",
-      "version": "4.0.0",
+      "identifier": "ghcr.io/startreedata/mcp-pinot:4.0.0",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github"
   },
   "websiteUrl": "https://startreedata.github.io/mcp-pinot/",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-pinot-server",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "transport": {
         "type": "stdio"
       },
@@ -71,7 +71,7 @@
       "registryType": "oci",
       "registryBaseUrl": "https://ghcr.io",
       "identifier": "ghcr.io/startreedata/mcp-pinot",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import os
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -343,3 +344,104 @@ class TestOAuthGrantedScopes:
             with patch.dict(os.environ, env, clear=True):
                 with pytest.raises(ValueError, match="OAUTH_GRANTED_SCOPES"):
                     build_auth(_cfg(auth_provider="oauth"))
+
+
+class TestOAuthPlusStatic:
+    """One deployment serving interactive users and one trusted backend."""
+
+    _ENV: ClassVar[dict[str, str]] = {
+        **_OAUTH_ENV,
+        "MCP_STATIC_TOKEN": "backend-secret",
+    }
+
+    def _build(self, **extra):
+        provider = extra.pop("_provider", "oauth+static")
+        env = {**self._ENV, **extra}
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                return build_auth(_cfg(auth_provider=provider))
+
+    def test_builds_an_oauth_proxy_so_the_login_routes_exist(self):
+        from fastmcp.server.auth import OAuthProxy
+
+        assert isinstance(self._build(), OAuthProxy)
+
+    def test_provider_name_order_is_irrelevant(self):
+        """The name describes a set of accepted credentials, not an order."""
+        from mcp_pinot.auth.multi import ChainedTokenVerifier
+
+        for name in ("oauth+static", "static+oauth", " oauth + static "):
+            auth = self._build(_provider=name)
+            assert isinstance(auth._token_validator, ChainedTokenVerifier)
+
+    def test_composite_provider_is_discoverable(self):
+        assert "oauth+static" in available_providers()
+
+    def test_missing_static_token_fails_startup(self):
+        """Asking for both and getting one silently would be worse than failing."""
+        env = {k: v for k, v in self._ENV.items() if k != "MCP_STATIC_TOKEN"}
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                with pytest.raises(ValueError, match="MCP_STATIC_TOKEN"):
+                    build_auth(_cfg(auth_provider="oauth+static"))
+
+    def test_incomplete_oauth_fails_startup(self):
+        env = {k: v for k, v in self._ENV.items() if k != "OAUTH_JWKS_URI"}
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                with pytest.raises(ValueError, match="OAUTH_JWKS_URI"):
+                    build_auth(_cfg(auth_provider="oauth+static"))
+
+    @pytest.mark.asyncio
+    async def test_the_shared_token_authenticates_with_its_own_scopes(self):
+        auth = self._build(MCP_STATIC_SCOPES="pinot:read")
+        token = await auth._token_validator.verify_token("backend-secret")
+        assert token is not None
+        assert token.scopes == ["pinot:read"]
+        assert token.client_id == "mcp-static-client"
+
+    @pytest.mark.asyncio
+    async def test_an_oidc_token_authenticates_with_the_granted_scopes(self):
+        """Reached only after the shared-token check misses."""
+        from mcp.server.auth.provider import AccessToken as UpstreamToken
+
+        auth = self._build(
+            MCP_STATIC_SCOPES="pinot:read",
+            OAUTH_GRANTED_SCOPES="pinot:read pinot:write",
+        )
+        upstream = UpstreamToken(token="jwt", client_id="alice", scopes=["openid"])
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            return_value=upstream,
+        ):
+            token = await auth._token_validator.verify_token("a-dex-jwt")
+        assert token.client_id == "alice"
+        assert token.scopes == ["openid", "pinot:read", "pinot:write"]
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_token_is_rejected(self):
+        auth = self._build()
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            return_value=None,
+        ):
+            assert await auth._token_validator.verify_token("neither") is None
+
+    @pytest.mark.asyncio
+    async def test_the_shared_token_short_circuits_the_oidc_check(self):
+        """The backend calls on every request; it must not pay for a JWKS fetch."""
+        from unittest.mock import AsyncMock
+
+        auth = self._build()
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            new_callable=AsyncMock,
+        ) as jwt_verify:
+            await auth._token_validator.verify_token("backend-secret")
+        jwt_verify.assert_not_awaited()
+
+    def test_chained_verifier_requires_at_least_one_verifier(self):
+        from mcp_pinot.auth.multi import ChainedTokenVerifier
+
+        with pytest.raises(ValueError, match="at least one"):
+            ChainedTokenVerifier([])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -218,3 +218,128 @@ class TestAuthProviderResolution:
             with patch.dict(os.environ, env, clear=True):
                 # Normalized to lower-case.
                 assert load_server_config().auth_provider == "startree"
+
+
+class TestOAuthAudience:
+    """OAUTH_AUDIENCE is optional and defaults to the canonical resource URI."""
+
+    @staticmethod
+    def _verifier(env):
+        from mcp_pinot.auth.oauth import build_token_verifier
+        from mcp_pinot.config import load_oauth_config
+
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                return build_token_verifier(load_oauth_config(), "/mcp")
+
+    def test_defaults_to_canonical_resource_uri(self):
+        env = {k: v for k, v in _OAUTH_ENV.items() if k != "OAUTH_AUDIENCE"}
+        assert self._verifier(env).audience == "http://localhost:8080/mcp"
+
+    def test_missing_audience_no_longer_blocks_startup(self):
+        """It used to raise, which made every Dex-backed deployment unstartable."""
+        env = {k: v for k, v in _OAUTH_ENV.items() if k != "OAUTH_AUDIENCE"}
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                build_auth(_cfg(auth_provider="oauth"))
+
+    def test_explicit_non_canonical_audience_is_honoured(self):
+        """Dex and friends set `aud` to the client ID; that must not be fatal."""
+        env = {**_OAUTH_ENV, "OAUTH_AUDIENCE": "startree-mcp-server"}
+        assert self._verifier(env).audience == "startree-mcp-server"
+
+    def test_non_canonical_audience_warns(self, caplog):
+        env = {**_OAUTH_ENV, "OAUTH_AUDIENCE": "startree-mcp-server"}
+        with caplog.at_level("WARNING", logger="mcp_pinot.auth.oauth"):
+            with patch("mcp_pinot.config.load_dotenv"):
+                with patch.dict(os.environ, env, clear=True):
+                    build_auth(_cfg(auth_provider="oauth"))
+        assert "canonical MCP resource URI" in caplog.text
+
+
+class TestOAuthGrantedScopes:
+    """Pinot scopes granted to principals an OIDC provider authenticates."""
+
+    @staticmethod
+    def _token(scopes):
+        from mcp.server.auth.provider import AccessToken
+
+        return AccessToken(token="t", client_id="c", scopes=list(scopes))
+
+    async def _verify(self, granted, token_scopes):
+        from mcp_pinot.auth.oauth import PinotScopeGrantingVerifier
+
+        verifier = PinotScopeGrantingVerifier(
+            jwks_uri=_OAUTH_ENV["OAUTH_JWKS_URI"],
+            issuer=_OAUTH_ENV["OAUTH_ISSUER"],
+            audience="aud",
+            granted_scopes=granted,
+        )
+        upstream = self._token(token_scopes)
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            return_value=upstream,
+        ):
+            return await verifier.verify_token("raw-token"), upstream
+
+    @pytest.mark.asyncio
+    async def test_grants_are_unioned_onto_token_scopes(self):
+        """Dex issues `openid`; the Pinot scopes have to come from configuration."""
+        result, _ = await self._verify(
+            ["pinot:read", "pinot:write", "pinot:admin"], ["openid"]
+        )
+        assert result.scopes == ["openid", "pinot:read", "pinot:write", "pinot:admin"]
+
+    @pytest.mark.asyncio
+    async def test_read_only_grant_withholds_write_and_admin(self):
+        result, _ = await self._verify(["pinot:read"], ["openid"])
+        assert result.scopes == ["openid", "pinot:read"]
+
+    @pytest.mark.asyncio
+    async def test_token_scopes_are_never_revoked(self):
+        """A provider that can mint Pinot scopes keeps them under a narrow grant."""
+        result, _ = await self._verify(["pinot:read"], ["pinot:read", "pinot:write"])
+        assert set(result.scopes) == {"pinot:read", "pinot:write"}
+
+    @pytest.mark.asyncio
+    async def test_no_grant_returns_token_untouched(self):
+        result, upstream = await self._verify([], ["openid"])
+        assert result is upstream
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_stays_rejected(self):
+        from mcp_pinot.auth.oauth import PinotScopeGrantingVerifier
+
+        verifier = PinotScopeGrantingVerifier(
+            jwks_uri=_OAUTH_ENV["OAUTH_JWKS_URI"],
+            issuer=_OAUTH_ENV["OAUTH_ISSUER"],
+            audience="aud",
+            granted_scopes=["pinot:read"],
+        )
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            return_value=None,
+        ):
+            assert await verifier.verify_token("bad") is None
+
+    @pytest.mark.asyncio
+    async def test_default_grant_is_the_full_pinot_scope_set(self):
+        from mcp_pinot.auth.oauth import build_token_verifier
+        from mcp_pinot.config import load_oauth_config
+
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, _OAUTH_ENV, clear=True):
+                verifier = build_token_verifier(load_oauth_config(), "/mcp")
+        with patch(
+            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
+            return_value=self._token(["openid"]),
+        ):
+            token = await verifier.verify_token("raw")
+        assert token.scopes == ["openid", "pinot:read", "pinot:write", "pinot:admin"]
+
+    def test_unsupported_grant_scope_raises(self):
+        env = {**_OAUTH_ENV, "OAUTH_GRANTED_SCOPES": "pinot:read superuser"}
+        with patch("mcp_pinot.config.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                with pytest.raises(ValueError, match="OAUTH_GRANTED_SCOPES"):
+                    build_auth(_cfg(auth_provider="oauth"))

--- a/tests/test_pinot_client.py
+++ b/tests/test_pinot_client.py
@@ -187,23 +187,97 @@ class TestPinotClient:
             assert result["connection_test"] is True
             assert result["query_test"] is True
             assert result["tables_test"] is True
+            assert result["dbapi_test"] is True
             assert result["error"] is None
             assert result["tables_count"] == 2
 
-    def test_test_connection_failure(self, mock_pinot_config):
-        """Test connection test with failure."""
+    def test_test_connection_reports_healthy_when_only_dbapi_probe_fails(
+        self, mock_pinot_config, mock_requests
+    ):
+        """A pinotdb incompatibility must not be reported as a dead deployment.
+
+        Regression test for the diagnostic that claimed every check failed on a
+        working StarTree deployment: pinotdb rejected the broker's response to
+        `SELECT 1` (check_sufficient_responded) while every tool, which goes over
+        the broker's REST endpoint, worked.
+        """
         pinot = PinotClient(mock_pinot_config)
 
-        with patch.object(pinot, "get_connection") as mock_get_conn:
-            mock_get_conn.side_effect = Exception("Connection failed")
+        with (
+            patch.object(pinot, "execute_query") as mock_query,
+            patch.object(pinot, "get_tables") as mock_tables,
+            patch.object(pinot, "get_connection") as mock_conn,
+        ):
+            mock_query.return_value = [{"test_column": 1}]
+            mock_tables.return_value = ["table1"]
+            mock_conn.side_effect = Exception("pinotdb: Query")
+
+            result = pinot.test_connection()
+
+        assert result["query_test"] is True
+        assert result["connection_test"] is True
+        assert result["tables_test"] is True
+        assert result["dbapi_test"] is False
+        assert result["error"] is None, "a DB-API-only failure must not report an error"
+
+    def test_test_connection_probes_the_path_read_query_uses(
+        self, mock_pinot_config, mock_requests
+    ):
+        """The query check must go through execute_query, not the DB-API cursor."""
+        pinot = PinotClient(mock_pinot_config)
+
+        with (
+            patch.object(pinot, "execute_query") as mock_query,
+            patch.object(pinot, "get_tables", return_value=[]),
+            patch.object(pinot, "get_connection", side_effect=Exception("unused")),
+        ):
+            mock_query.return_value = [{"test_column": 1}]
+            pinot.test_connection()
+
+        assert mock_query.call_count == 1
+        assert "SELECT 1" in mock_query.call_args.args[0].upper()
+
+    def test_test_connection_failure(self, mock_pinot_config):
+        """Both required checks failing is reported, without leaking detail."""
+        pinot = PinotClient(mock_pinot_config)
+
+        with (
+            patch.object(pinot, "execute_query") as mock_query,
+            patch.object(pinot, "get_tables") as mock_tables,
+            patch.object(pinot, "get_connection") as mock_conn,
+        ):
+            mock_query.side_effect = Exception("Connection failed")
+            mock_tables.side_effect = Exception("Connection failed")
+            mock_conn.side_effect = Exception("Connection failed")
 
             result = pinot.test_connection()
 
             assert result["connection_test"] is False
             assert result["query_test"] is False
             assert result["tables_test"] is False
+            assert result["dbapi_test"] is False
             assert "connectivity check failed" in result["error"]
+            assert "broker query" in result["error"]
+            assert "controller table listing" in result["error"]
             assert "Connection failed" not in result["error"]
+
+    def test_test_connection_names_only_the_failed_check(
+        self, mock_pinot_config, mock_requests
+    ):
+        """A half-broken deployment says which half."""
+        pinot = PinotClient(mock_pinot_config)
+
+        with (
+            patch.object(pinot, "execute_query", return_value=[{"test_column": 1}]),
+            patch.object(pinot, "get_tables", side_effect=Exception("controller down")),
+            patch.object(pinot, "get_connection", side_effect=Exception("unused")),
+        ):
+            result = pinot.test_connection()
+
+        assert result["query_test"] is True
+        assert result["tables_test"] is False
+        assert "controller table listing" in result["error"]
+        assert "broker query" not in result["error"]
 
     def test_execute_query_http_success(self, mock_pinot_config, mock_requests):
         """Test successful HTTP query execution."""

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import re
 import tomllib
 
+from scripts.prepare_registry_metadata import prepare_metadata
+
 ROOT = Path(__file__).resolve().parents[1]
 
 EXPECTED_TOOL_NAMES = {
@@ -144,7 +146,17 @@ def test_release_versions_are_aligned() -> None:
     assert manifest["manifest_version"] == "0.4"
     assert manifest["version"] == version
     assert registry["version"] == version
-    assert {package["version"] for package in registry["packages"]} == {version}
+    versioned_packages = [
+        package for package in registry["packages"] if package["registryType"] != "oci"
+    ]
+    assert {package["version"] for package in versioned_packages} == {version}
+    oci_packages = [
+        package for package in registry["packages"] if package["registryType"] == "oci"
+    ]
+    assert oci_packages
+    assert all(
+        package["identifier"].endswith(f":{version}") for package in oci_packages
+    )
     assert chart_version == version
     assert chart_app_version == version
     assert locked_project["version"] == version
@@ -198,6 +210,10 @@ def test_registry_and_release_metadata_are_publishable_and_pinned() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert 1 <= len(registry["description"]) <= 100
+    for package in registry["packages"]:
+        if package["registryType"] == "oci":
+            assert "registryBaseUrl" not in package
+            assert "version" not in package
     assert (
         'LABEL io.modelcontextprotocol.server.name="io.github.startreedata/mcp-pinot"'
         in dockerfile
@@ -213,3 +229,38 @@ def test_registry_and_release_metadata_are_publishable_and_pinned() -> None:
     )
     assert ">=9.1.2" in pinotdb and "<10" in pinotdb
     assert '"4.0.0"' not in (ROOT / "mcp_pinot/__init__.py").read_text(encoding="utf-8")
+
+
+def test_registry_metadata_preparation_uses_canonical_oci_references(tmp_path) -> None:
+    metadata_path = tmp_path / "server.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "version": "4.0.0",
+                "packages": [
+                    {
+                        "registryType": "pypi",
+                        "identifier": "mcp-pinot-server",
+                        "version": "4.0.0",
+                    },
+                    {
+                        "registryType": "oci",
+                        "registryBaseUrl": "https://ghcr.io",
+                        "identifier": "ghcr.io/startreedata/mcp-pinot:4.0.0",
+                        "version": "4.0.0",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    prepare_metadata(metadata_path, "v4.0.1")
+
+    prepared = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert prepared["version"] == "4.0.1"
+    assert prepared["packages"][0]["version"] == "4.0.1"
+    assert prepared["packages"][1] == {
+        "registryType": "oci",
+        "identifier": "ghcr.io/startreedata/mcp-pinot:4.0.1",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -941,7 +941,7 @@ cli = [
 
 [[package]]
 name = "mcp-pinot-server"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- encode OCI release tags in the canonical `identifier` and remove forbidden OCI `registryBaseUrl`/`version` fields
- centralize registry metadata preparation so tag releases cannot reintroduce legacy OCI fields
- add a manually dispatched, OIDC-authenticated MCP Registry retry workflow for partial-release recovery
- add regression tests for registry-specific package metadata

## Incident and recovery

The v4.0.0 release successfully published PyPI, GHCR, Helm, MCPB, and the GitHub release, but the registry rejected the legacy OCI field shape. The scoped recovery workflow on this branch published the existing v4.0.0 artifacts successfully without moving the tag or republishing packages.

## Verification

- 289 passed, 7 expected integration skips
- Ruff format/lint and mypy pass
- actionlint v1.7.7 passes
- pinned mcp-publisher v1.8.0 validation passes
- live MCP Registry now lists `io.github.startreedata/mcp-pinot` version 4.0.0 with canonical `ghcr.io/startreedata/mcp-pinot:4.0.0` metadata
