### PR TITLE
fix(auth): accept static token through hybrid HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `AUTH_PROVIDER=oauth+static` (either spelling) accepts **both** an OIDC login and
-  the static shared token on one deployment, through a `ChainedTokenVerifier` behind
-  the OAuth provider. A hosted MCP normally has both kinds of caller — people with a
-  browser and one trusted backend without one — and selecting a single provider forced
-  a choice between them, with no clean workaround (a second deployment needs a second
-  hostname and certificate; many IdPs cannot issue the client-credentials grant).
-  The shared secret is checked first, so the backend never pays for a signing-key
-  fetch, and each credential keeps its own scopes: `MCP_STATIC_SCOPES` for the backend,
-  `OAUTH_GRANTED_SCOPES` for people. Chart: `mcp.auth.provider: oauth+static`.
+  the static shared token on one deployment. An OAuth proxy retains the interactive
+  discovery/login routes while checking the shared token at the client-facing MCP
+  endpoint before delegating other credentials to the OAuth flow. A hosted MCP
+  normally has both kinds of caller — people with a browser and one trusted backend
+  without one — and selecting a single provider forced a choice between them, with no
+  clean workaround (a second deployment needs a second hostname and certificate;
+  many IdPs cannot issue the client-credentials grant). Each credential keeps its own
+  scopes: `MCP_STATIC_SCOPES` for the backend, `OAUTH_GRANTED_SCOPES` for people.
+  Chart: `mcp.auth.provider: oauth+static`.
 - `OAUTH_GRANTED_SCOPES` (default `pinot:read pinot:write pinot:admin`): Pinot
   authorization scopes granted to every principal the OAuth provider
   authenticates, unioned onto the scopes the token already carries. General-purpose
@@ -38,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pick, paste, or distribute a token.
 
 ### Fixed
+- Hybrid `oauth+static` deployments now accept the raw shared bearer token at the
+  real HTTP MCP endpoint. `OAuthProxy` first validates its own client-facing JWT
+  and only calls its configured verifier after swapping for the stored upstream
+  token, so placing a static verifier behind the proxy made direct static requests
+  return `401` even though verifier-only unit tests passed.
 - `test_connection` no longer reports a healthy deployment as broken. It probed
   through the pinotdb DB-API connection, which no tool uses: against a broker whose
   response pinotdb rejects (`check_sufficient_responded`) it returned

--- a/mcp_pinot/auth/multi.py
+++ b/mcp_pinot/auth/multi.py
@@ -12,11 +12,12 @@ workaround: a second deployment means a second hostname and certificate, and man
 identity providers cannot issue the client-credentials grant a backend would need.
 
 So ``AUTH_PROVIDER=oauth+static`` builds the OAuth provider — which owns the
-discovery, registration and authorization routes people need — and gives it a
-:class:`ChainedTokenVerifier` that recognises the shared secret as well as an OIDC
-token. Both spellings (``static+oauth``) select the same thing; the shared secret is
-always tried first because that check is a constant-time comparison, while the OIDC
-path may fetch signing keys.
+discovery, registration and authorization routes people need — and wraps its
+client-facing token validation so it recognises the shared secret before trying a
+FastMCP-issued OAuth token. Both spellings (``static+oauth``) select the same thing;
+the shared secret is always tried first because that check is a constant-time
+comparison, while the OAuth path may validate a signed token and fetch signing
+keys for its upstream token.
 
 Each credential keeps its own authorization: the shared secret carries
 ``MCP_STATIC_SCOPES`` and an OIDC user carries ``OAUTH_GRANTED_SCOPES``, so a
@@ -24,7 +25,7 @@ backend can be read-only while people retain write access, or the reverse. The
 principals stay distinguishable in logs by ``client_id``.
 """
 
-from collections.abc import Sequence
+from typing import Any, cast
 
 from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.auth import AccessToken, TokenVerifier
@@ -36,29 +37,37 @@ from mcp_pinot.config import ServerConfig, get_logger, load_oauth_config
 logger = get_logger()
 
 
-class ChainedTokenVerifier(TokenVerifier):
-    """Verify a bearer token against several verifiers, in order.
+class OAuthStaticProxy(OAuthProxy):
+    """OAuth proxy that also accepts a raw static bearer token at the MCP route.
 
-    The first verifier that recognises the token decides the request, including
-    the scopes the resulting principal holds. A token no verifier recognises is
-    rejected exactly as a single verifier would reject it.
+    ``OAuthProxy`` does not pass the bearer token received by the MCP endpoint to
+    its configured ``token_verifier``. It first requires a FastMCP-issued JWT,
+    swaps that JWT for the stored upstream token, and only then invokes the
+    verifier. Consequently, putting the static verifier inside
+    ``OAuthProxy(token_verifier=...)`` cannot authenticate a raw shared secret.
+
+    This subclass checks the static credential at the client-facing boundary and
+    delegates every other token to the unmodified OAuth proxy flow. The upstream
+    OAuth verifier remains dedicated to validating the swapped OIDC token.
     """
 
-    def __init__(self, verifiers: Sequence[TokenVerifier]) -> None:
-        if not verifiers:
-            raise ValueError("ChainedTokenVerifier requires at least one verifier.")
-        # Advertise the union of nothing: per-tool Pinot scopes are enforced on the
-        # component, and a baseline shared by unrelated credential types would
-        # reject one of them. Individual verifiers keep their own required_scopes.
-        super().__init__(required_scopes=None)
-        self._verifiers = list(verifiers)
+    def __init__(
+        self,
+        *,
+        static_token_verifier: TokenVerifier,
+        **kwargs: Any,
+    ) -> None:
+        self._static_token_verifier = static_token_verifier
+        super().__init__(**kwargs)
 
-    async def verify_token(self, token: str) -> AccessToken | None:
-        for verifier in self._verifiers:
-            access_token = await verifier.verify_token(token)
-            if access_token is not None:
-                return access_token
-        return None
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        static_access = await self._static_token_verifier.verify_token(token)
+        if static_access is not None:
+            return static_access
+        # OAuthProxy's public annotation comes from the base MCP package, while
+        # FastMCP's override contract and configured verifier use its AccessToken
+        # subclass. The value returned here originates from that verifier.
+        return cast(AccessToken | None, await super().load_access_token(token))
 
 
 def build_oauth_static_auth(server_config: ServerConfig) -> OAuthProxy:
@@ -79,14 +88,16 @@ def build_oauth_static_auth(server_config: ServerConfig) -> OAuthProxy:
         " ".join(oauth_config.granted_scopes or []),
     )
 
-    return OAuthProxy(
+    return OAuthStaticProxy(
         upstream_authorization_endpoint=oauth_config.upstream_authorization_endpoint,
         upstream_token_endpoint=oauth_config.upstream_token_endpoint,
         upstream_client_id=oauth_config.client_id,
         upstream_client_secret=oauth_config.client_secret,
-        # Shared secret first: a constant-time comparison, and it avoids a signing-key
-        # fetch for the backend caller that sends it on every request.
-        token_verifier=ChainedTokenVerifier([static_verifier, oidc_verifier]),
+        # OAuthProxy invokes this only after swapping its own client-facing JWT for
+        # the upstream OIDC token.
+        token_verifier=oidc_verifier,
+        # The raw static bearer token is checked at the client-facing boundary.
+        static_token_verifier=static_verifier,
         extra_authorize_params=oauth_config.extra_authorize_params,
         base_url=oauth_config.base_url,
         valid_scopes=oauth_config.scopes,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -368,11 +368,11 @@ class TestOAuthPlusStatic:
 
     def test_provider_name_order_is_irrelevant(self):
         """The name describes a set of accepted credentials, not an order."""
-        from mcp_pinot.auth.multi import ChainedTokenVerifier
+        from mcp_pinot.auth.multi import OAuthStaticProxy
 
         for name in ("oauth+static", "static+oauth", " oauth + static "):
             auth = self._build(_provider=name)
-            assert isinstance(auth._token_validator, ChainedTokenVerifier)
+            assert isinstance(auth, OAuthStaticProxy)
 
     def test_composite_provider_is_discoverable(self):
         assert "oauth+static" in available_providers()
@@ -395,10 +395,48 @@ class TestOAuthPlusStatic:
     @pytest.mark.asyncio
     async def test_the_shared_token_authenticates_with_its_own_scopes(self):
         auth = self._build(MCP_STATIC_SCOPES="pinot:read")
-        token = await auth._token_validator.verify_token("backend-secret")
+        token = await auth.load_access_token("backend-secret")
         assert token is not None
         assert token.scopes == ["pinot:read"]
         assert token.client_id == "mcp-static-client"
+
+    @pytest.mark.asyncio
+    async def test_oauth_routes_and_static_token_work_on_the_same_http_app(self):
+        """Regression: OAuthProxy must not reject the raw shared bearer token."""
+        from fastmcp import FastMCP
+        import httpx
+
+        auth = self._build(MCP_STATIC_SCOPES="pinot:read")
+        app = FastMCP("hybrid-test", auth=auth).http_app(path="/mcp")
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "hybrid-test", "version": "1"},
+            },
+        }
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Authorization": "Bearer backend-secret",
+        }
+
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://localhost:8080"
+            ) as client:
+                discovery = await client.get(
+                    "/.well-known/oauth-protected-resource/mcp"
+                )
+                initialize_response = await client.post(
+                    "/mcp", json=initialize, headers=headers
+                )
+
+        assert discovery.status_code == 200
+        assert initialize_response.status_code == 200
 
     @pytest.mark.asyncio
     async def test_an_oidc_token_authenticates_with_the_granted_scopes(self):
@@ -425,23 +463,19 @@ class TestOAuthPlusStatic:
             "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
             return_value=None,
         ):
-            assert await auth._token_validator.verify_token("neither") is None
+            assert await auth.load_access_token("neither") is None
 
     @pytest.mark.asyncio
     async def test_the_shared_token_short_circuits_the_oidc_check(self):
         """The backend calls on every request; it must not pay for a JWKS fetch."""
         from unittest.mock import AsyncMock
 
+        from fastmcp.server.auth import OAuthProxy
+
         auth = self._build()
-        with patch(
-            "fastmcp.server.auth.providers.jwt.JWTVerifier.verify_token",
-            new_callable=AsyncMock,
-        ) as jwt_verify:
-            await auth._token_validator.verify_token("backend-secret")
-        jwt_verify.assert_not_awaited()
-
-    def test_chained_verifier_requires_at_least_one_verifier(self):
-        from mcp_pinot.auth.multi import ChainedTokenVerifier
-
-        with pytest.raises(ValueError, match="at least one"):
-            ChainedTokenVerifier([])
+        with patch.object(
+            OAuthProxy, "load_access_token", new_callable=AsyncMock
+        ) as oauth_load:
+            token = await auth.load_access_token("backend-secret")
+        assert token is not None
+        oauth_load.assert_not_awaited()


### PR DESCRIPTION
## What changed

Hybrid oauth+static mode now checks the raw shared bearer token at the client-facing MCP boundary, while delegating all other tokens to the unchanged OAuthProxy JWT and upstream-token flow.

## Why

A release-image smoke test showed the real HTTP MCP endpoint returned 401 for the configured static token. OAuthProxy validates its own client-facing JWT first and only invokes token_verifier after swapping for the stored upstream token, so chaining the static verifier behind OAuthProxy could never authenticate a raw shared secret.

## Validation

- 313 tests passed, 7 skipped
- New ASGI regression: OAuth discovery is available and static-token initialize returns 200 on the same app
- Ruff passed
- Helm smoke and lint passed
- Built linux/amd64 image and booted it in oauth+static mode
- /livez 200, /readyz 200, OAuth discovery 200
- unauthenticated initialize 401, static-token initialize 200 with valid MCP 4.1.0 response