### PR TITLE
Make Dockerfile work without BuildKit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN groupadd --gid 1000 appuser \
     && chown -R 1000:1000 /app
 
 COPY --from=builder /app/.venv /app/.venv
-COPY --chmod=0555 run.sh /app/run.sh
+COPY run.sh /app/run.sh
+RUN chmod 0555 /app/run.sh
 
 USER 1000:1000
 


### PR DESCRIPTION
## Summary

Make the Dockerfile compatible with Docker builds that do not have BuildKit enabled.

## Changes

- Replace `COPY --chmod=0555 run.sh /app/run.sh` with a regular `COPY`
- Add an explicit `RUN chmod 0555 /app/run.sh`

## Testing

- Verified the change is limited to the Dockerfile